### PR TITLE
Provide actual branch name in CI configuration

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches:
-      - $default-branch
+      - master
   pull_request:
     branches:
-      - $default-branch
+      - master
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
GitHub Actions templates specify `$default-branch`, but it's not a real environment variable. When using GitHub's interface to add a workflow from a template, that string is replaced by the repository's *real* default branch name:

https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization