### PR TITLE
CI Fix: Provide environment variables for CI jobs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - master
 
+env:
+  API_ROOT: "http://localhost:3000"
+  FRONTEND_MOCK_API_SERVER: "true"
+  FRONTEND_PROD_SITE_ROOT: "https://example.com"
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Some tests were failing in CI because of missing environment variables. The tests passed in development because env vars were set from the git-ignored `.env` file.