### PR TITLE
Update TypeScript configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,10 @@ module.exports = {
     "@typescript-eslint/consistent-type-imports": ["error"],
 
     // Allow unused function parameters if they start with an underscore
-    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { args: "all", argsIgnorePattern: "^_" },
+    ],
 
     // Use TypeScript-aware implementation of this built-in rule
     "no-use-before-define": "off",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ export default App;
 
 // Render the app
 if (typeof document !== "undefined") {
-  const target = document.getElementById("root");
+  const target = document.getElementById("root") as HTMLElement;
 
   const renderMethod = target.hasChildNodes()
     ? ReactDOM.hydrate

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -43,10 +43,13 @@ export const HEADERS: Record<string, string | string[]> = {
   "Access-Control-Allow-Origin": "*",
 } as const;
 
-export const handlers: RequestHandler[] = [
+// We need `any` in the type here to allow handlers to respond differently:
+// https://github.com/mswjs/msw/issues/377#issuecomment-690536532
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handlers: RequestHandler<any, any, any, any>[] = [
   // Create a handler for each top level MOCK_DATA key; The handler for
   // a given key uses the URL defined in ENDPOINTS under the same key
-  ...Object.keys(MOCK_DATA).map((key: keyof typeof MOCK_DATA) => {
+  ...(Object.keys(MOCK_DATA) as Array<keyof typeof MOCK_DATA>).map((key) => {
     return rest.get(ENDPOINTS[key], (_req, res, ctx) => {
       return res(ctx.set(HEADERS), ctx.json({ [key]: MOCK_DATA[key] }));
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
-    "noImplicitAny": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "paths": {
       "#src/*": ["src/*"],
       "#components/*": ["src/components/*"],
@@ -26,6 +23,7 @@
     "removeComments": false,
     "skipLibCheck": true,
     "sourceMap": true,
+    "strict": true,
     "target": "esnext"
   },
   "include": ["src/**/*", "types/**/*", "tests/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,18 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "jsx": "react",
     "allowJs": false,
-    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
     "esModuleInterop": true,
+    "jsx": "react",
+    "lib": ["dom", "es2015", "es2016", "DOM.Iterable"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "#src/*": ["src/*"],
       "#components/*": ["src/components/*"],
@@ -26,7 +22,11 @@
       "#api_endpoints": ["src/api_endpoints.ts"],
       "#server_routes.mock": ["src/server_routes.mock.ts"]
     },
-    "lib": ["dom", "es2015", "es2016", "DOM.Iterable"]
+    "preserveConstEnums": true,
+    "removeComments": false,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "target": "esnext"
   },
   "include": ["src/**/*", "types/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
- Sorted `tsconfig.json` keys alphabetically
- Updated `tsconfig.json` to use strict type checking
    - Removed `"noImplicitAny"`, which is included in "strict"
    - Removed `"noUnusedLocals"` and `"noUnusedParameters"` because these checks are performed by eslint
    - Updated `.eslintrc.js` to match the behavior of `"noUnusedParameters"`: Requiring a leading `_` for unused params, even if there are used params after them
    - Addressed a couple typing issues caused by the stricter checks
