### PR TITLE
Factor out API request logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3760,6 +3760,14 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "axios-retry": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.9.tgz",
+      "integrity": "sha512-NFCoNIHq8lYkJa6ku4m+V1837TP6lCa7n79Iuf8/AqATAHYB0ISaAS1eyIenDOfHOLtym34W65Sjke2xjg2fsA==",
+      "requires": {
+        "is-retry-allowed": "^1.1.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@material-ui/icons": "^4.9.1",
     "@reach/router": "^1.2.1",
     "axios": "^0.20.0",
+    "axios-retry": "^3.1.9",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-hot-loader": "^4.12.21",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,57 @@
+import axios from "axios";
+import type { AxiosError, AxiosResponse } from "axios";
+import axiosRetry, {
+  exponentialDelay,
+  isNetworkOrIdempotentRequestError,
+} from "axios-retry";
+
+import { ENDPOINTS } from "#api_endpoints";
+import type { ICategories, IUsers } from "#src/types";
+
+export interface APIError extends AxiosError {
+  uiErrorMessage: string;
+}
+
+axiosRetry(axios, {
+  retries: 3,
+  retryCondition: isNetworkOrIdempotentRequestError,
+  retryDelay: exponentialDelay,
+});
+
+// This function always throws, but we specify a return type so that tsc doesn't
+// include `void` in the the type for the `api.foo().then()` handler's parameter
+function errorHandler(err: AxiosError): AxiosResponse {
+  let message: string;
+
+  if (err.response) {
+    const { status, statusText } = err.response;
+    message =
+      `Error from server: "${status} ${statusText}".` +
+      " Please send a bug report!";
+  } else if (err.request) {
+    message = "Couldn't reach the server. Please try reloading in a minute.";
+  } else {
+    message = `Unknown error: ${err.message}\n${err.toString()}\n${err.stack}`;
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  (err as APIError).uiErrorMessage = message;
+  throw err;
+}
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types
+   --
+   The inferred types include the type of the AJAX response object for each
+   endpoint (e.g.  ICategories), which is more valuable than either a more
+   generic type or the clutter of defining each endpoint's type explicitly
+*/
+export const api = {
+  getCategories: () =>
+    axios
+      .get<ICategories>(ENDPOINTS.categories)
+      .catch<AxiosResponse<ICategories>>(errorHandler),
+  getUsers: () =>
+    axios
+      .get<IUsers>(ENDPOINTS.users)
+      .catch<AxiosResponse<IUsers>>(errorHandler),
+} as const;

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -1,0 +1,127 @@
+import {
+  rest,
+  server,
+  ENDPOINTS,
+  HEADERS,
+  MOCK_DATA,
+} from "#test_helpers/server";
+import { api } from "#api";
+import type { APIError } from "#api";
+
+type MethodTestSpec = readonly [
+  method: keyof typeof api,
+  endpoint: keyof typeof ENDPOINTS,
+  dataKey: keyof typeof MOCK_DATA
+];
+
+const HTTP_GET_ENDPOINTS: readonly MethodTestSpec[] = [
+  ["getCategories", "categories", "categories"],
+  ["getUsers", "users", "users"],
+];
+
+describe("api", () => {
+  describe("given a successful API response", () => {
+    test.each(HTTP_GET_ENDPOINTS)(
+      '.%s() returns "%s" data',
+      async (method, _endpoint, dataKey) => {
+        const result = await api[method]();
+        expect(result).not.toHaveProperty("uiErrorMessage");
+        expect(result.data).toStrictEqual({ [dataKey]: MOCK_DATA[dataKey] });
+      }
+    );
+  });
+
+  describe("given a network error", () => {
+    test.each(HTTP_GET_ENDPOINTS)(
+      ".%s() returns a network error message if the error is persistent",
+      (method, endpoint) => {
+        server.use(
+          rest.get(ENDPOINTS[endpoint], (_req, res) => {
+            return res.networkError("Failed to connect");
+          })
+        );
+
+        expect.assertions(1);
+
+        return (api[method]() as Promise<unknown>).catch((err: APIError) => {
+          expect(err.uiErrorMessage).toStrictEqual(
+            "Couldn't reach the server. Please try reloading in a minute."
+          );
+        });
+      }
+    );
+
+    // TODO Enable this test (remove `.skip`) when it's possible to implement it
+    test.skip.each(HTTP_GET_ENDPOINTS)(
+      ".%s() retries the request",
+      async (method, endpoint, dataKey) => {
+        server.use(
+          rest.get(ENDPOINTS[endpoint], (_req, res) => {
+            // TODO Return a NetworkError one time (the API doesn't exist yet):
+            // https://github.com/mswjs/msw/issues/413
+            return res.once(/* Do something */);
+          })
+        );
+
+        expect.assertions(1);
+
+        try {
+          const { data } = await api[method]();
+          expect(data).toStrictEqual({ [dataKey]: MOCK_DATA[dataKey] });
+        } catch (err) {
+          expect(err).not.toBeDefined();
+        }
+      }
+    );
+  });
+
+  describe("given a 500 status code", () => {
+    test.each(HTTP_GET_ENDPOINTS)(
+      ".%s() returns a status error message if the error is persistent",
+      (method, endpoint) => {
+        server.use(
+          rest.get(ENDPOINTS[endpoint], (_req, res, ctx) => {
+            return res(ctx.set(HEADERS), ctx.status(500, "My Error"));
+          })
+        );
+
+        expect.assertions(1);
+        return (api[method]() as Promise<unknown>).catch((err: APIError) => {
+          expect(err.uiErrorMessage).toStrictEqual(
+            'Error from server: "500 My Error". Please send a bug report!'
+          );
+        });
+      }
+    );
+
+    test.each(HTTP_GET_ENDPOINTS)(
+      ".%s() retries the request",
+      async (method, endpoint, dataKey) => {
+        server.use(
+          rest.get(ENDPOINTS[endpoint], (_req, res, ctx) => {
+            return res.once(ctx.set(HEADERS), ctx.status(500, "My Error"));
+          })
+        );
+
+        expect.assertions(1);
+
+        try {
+          const { data } = await api[method]();
+          expect(data).toStrictEqual({ [dataKey]: MOCK_DATA[dataKey] });
+        } catch (err) {
+          expect(err).not.toBeDefined();
+        }
+      }
+    );
+  });
+
+  /*
+   * NOTE: We're not testing `errorHandler()`'s "Unknown error" branch.
+   *
+   * I'm not sure how to trigger that branch with real request behavior. If I
+   * knew, it wouldn't be an unknown error and we could provide a better
+   * message. We could unit test `errorHandler()` with an object lacking
+   * `.response` and `.request`, but that would just be testing JavaScript's
+   * `else` keyword, it wouldn't provide any confidence about app behavior.
+   */
+});

--- a/src/components/ApiDiv.tsx
+++ b/src/components/ApiDiv.tsx
@@ -1,21 +1,20 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
 
-import { ENDPOINTS } from "#api_endpoints";
-import type { IUsers } from "#src/types";
+import { api } from "#api";
+import type { APIError } from "#api";
 
 export function ApiDiv(): JSX.Element {
   const [content, setContent] = useState("...Loading");
 
   useEffect(() => {
-    axios
-      .get<IUsers>(ENDPOINTS.users)
-      .then(({ data }) => {
+    api.getUsers().then(
+      ({ data }) => {
         setContent(`Users: ${JSON.stringify(data)}`);
-      })
-      .catch(() => {
-        setContent("Failed to load data from the API");
-      });
+      },
+      (err: APIError) => {
+        setContent(err.uiErrorMessage);
+      }
+    );
   }, []);
 
   return <div>{content}</div>;

--- a/src/components/ApiDiv.unit.test.tsx
+++ b/src/components/ApiDiv.unit.test.tsx
@@ -26,7 +26,7 @@ describe("<ApiDiv />", () => {
         rest.get(ENDPOINTS.users, (_req, res) => res.networkError("Net fail"))
       );
       render(<ApiDiv />);
-      await screen.findByText(/failed/i);
+      await screen.findByText(/couldn't reach the server/i);
     });
   });
 });

--- a/src/components/BurgerButton.unit.test.tsx
+++ b/src/components/BurgerButton.unit.test.tsx
@@ -7,14 +7,14 @@ const noop = (): void => undefined;
 
 describe("<BurgerButton />", () => {
   describe("given navIsVisible=true", () => {
-    it("Renders 'close menu' interface", () => {
+    it("renders 'close menu' interface", () => {
       render(<BurgerButton navIsVisible onClick={noop} />);
       expect(screen.getByLabelText(/close menu/i)).toBeInTheDocument();
     });
   });
 
   describe("given navIsVisible=false", () => {
-    it("Renders 'open menu' interface", () => {
+    it("renders 'open menu' interface", () => {
       render(<BurgerButton navIsVisible={false} onClick={noop} />);
       expect(screen.getByLabelText(/open menu/i)).toBeInTheDocument();
     });

--- a/src/layouts/Categories.tsx
+++ b/src/layouts/Categories.tsx
@@ -1,0 +1,36 @@
+import React, { Fragment } from "react";
+
+import { Category } from "#components/Category";
+import type { ICategory } from "#src/types";
+
+export interface CategoriesProps {
+  categories: ICategory[];
+  loadingMessage: string;
+}
+
+export function Categories({
+  categories,
+  loadingMessage,
+}: CategoriesProps): JSX.Element {
+  return (
+    <>
+      <h2>Categories</h2>
+      {categories.length === 0 ? (
+        <p>{loadingMessage}</p>
+      ) : (
+        categories.map(({ name, itemCount, summary, description }, index) => (
+          <Fragment key={name}>
+            {index > 0 ? <hr /> : undefined}
+            <Category
+              name={name}
+              itemCount={itemCount}
+              summary={summary}
+              description={description}
+              url={`/category/${name.toLowerCase()}/`}
+            />
+          </Fragment>
+        ))
+      )}
+    </>
+  );
+}

--- a/src/layouts/Categories.unit.test.tsx
+++ b/src/layouts/Categories.unit.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import type { ICategory } from "#src/types";
+import { Categories } from "./Categories";
+
+const MESSAGE = "I'm loading";
+
+const CATEGORY1: ICategory = {
+  name: "Foo",
+  itemCount: 5,
+  summary: "Foo summary",
+  description: "A description of Foo",
+} as const;
+
+const CATEGORY2: ICategory = {
+  name: "Bar",
+  itemCount: 7,
+  summary: "Bar summary",
+  description: "A description of Bar",
+} as const;
+
+describe("<Categories />", () => {
+  describe("given 0 category objects", () => {
+    it("renders the loading message", () => {
+      render(<Categories categories={[]} loadingMessage="I'm loading" />);
+      expect(screen.getByText("I'm loading")).toBeInTheDocument();
+    });
+  });
+
+  describe("given 1 category object", () => {
+    it("renders the category", () => {
+      render(<Categories categories={[CATEGORY1]} loadingMessage={MESSAGE} />);
+      // We're only testing that <Category /> is rendered, not testing all props
+      expect(screen.getByText(CATEGORY1.description)).toBeInTheDocument();
+    });
+
+    it("does NOT render the loading message", () => {
+      render(<Categories categories={[CATEGORY1]} loadingMessage={MESSAGE} />);
+      expect(screen.queryByText(MESSAGE)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given 2 category objects", () => {
+    const categories = [CATEGORY1, CATEGORY2];
+
+    it("renders both categories", () => {
+      render(<Categories categories={categories} loadingMessage={MESSAGE} />);
+      // We're only testing that <Category /> is rendered, not testing all props
+      expect(screen.getByText(CATEGORY1.description)).toBeInTheDocument();
+      expect(screen.getByText(CATEGORY2.description)).toBeInTheDocument();
+    });
+
+    it("does NOT render the loading message", () => {
+      render(<Categories categories={categories} loadingMessage={MESSAGE} />);
+      expect(screen.queryByText(MESSAGE)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -1,50 +1,30 @@
 import type { RouteComponentProps } from "@reach/router";
-import React, { Fragment, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { api } from "#api";
 import type { APIError } from "#api";
-import { Category } from "#components/Category";
+import { Categories } from "#layouts/Categories";
 import type { ICategory } from "#src/types";
 
-export default function Categories(_: RouteComponentProps): JSX.Element {
+export default function CategoriesPage(_: RouteComponentProps): JSX.Element {
   const [categories, setCategories] = useState<ICategory[]>([]);
-  const [loadStateMessage, setLoadStateMessage] = useState("...Loading");
+  const [loadingMessage, setLoadingMessage] = useState("...Loading");
 
   useEffect(() => {
     api.getCategories().then(
       ({ data }) => {
         if (data.categories.length > 0) {
           setCategories(data.categories);
-          setLoadStateMessage("");
+          setLoadingMessage("");
         } else {
-          setLoadStateMessage("No categories have been defined yet.");
+          setLoadingMessage("No categories have been defined yet.");
         }
       },
       (err: APIError) => {
-        setLoadStateMessage(err.uiErrorMessage);
+        setLoadingMessage(err.uiErrorMessage);
       }
     );
   }, []);
 
-  return (
-    <>
-      <h2>Categories</h2>
-      {categories.length === 0 ? (
-        <p>{loadStateMessage}</p>
-      ) : (
-        categories.map(({ name, itemCount, summary, description }, index) => (
-          <Fragment key={name}>
-            {index > 0 ? <hr /> : undefined}
-            <Category
-              name={name}
-              itemCount={itemCount}
-              summary={summary}
-              description={description}
-              url={`/category/${name.toLowerCase()}/`}
-            />
-          </Fragment>
-        ))
-      )}
-    </>
-  );
+  return <Categories categories={categories} loadingMessage={loadingMessage} />;
 }

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -1,41 +1,29 @@
-import axios from "axios";
-import type { AxiosError } from "axios";
 import type { RouteComponentProps } from "@reach/router";
 import React, { Fragment, useEffect, useState } from "react";
 
-import { ENDPOINTS } from "#api_endpoints";
+import { api } from "#api";
+import type { APIError } from "#api";
 import { Category } from "#components/Category";
-import type { ICategory, ICategories } from "#src/types";
+import type { ICategory } from "#src/types";
 
 export default function Categories(_: RouteComponentProps): JSX.Element {
   const [categories, setCategories] = useState<ICategory[]>([]);
   const [loadStateMessage, setLoadStateMessage] = useState("...Loading");
 
   useEffect(() => {
-    axios
-      .get<ICategories>(ENDPOINTS.categories)
-      .then(({ data }) => {
+    api.getCategories().then(
+      ({ data }) => {
         if (data.categories.length > 0) {
           setCategories(data.categories);
           setLoadStateMessage("");
         } else {
           setLoadStateMessage("No categories have been defined yet.");
         }
-      })
-      .catch((err: AxiosError) => {
-        if (err.response) {
-          const { status } = err.response;
-          setLoadStateMessage(
-            `Error from server: ${status}. Please send a bug report!`
-          );
-        } else if (err.request) {
-          setLoadStateMessage(
-            "Couldn't reach the server. Please try reloading in a minute."
-          );
-        } else {
-          setLoadStateMessage(`Unknown error: ${err.message}`);
-        }
-      });
+      },
+      (err: APIError) => {
+        setLoadStateMessage(err.uiErrorMessage);
+      }
+    );
   }, []);
 
   return (

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -1,6 +1,8 @@
-// This file is only used in development and *should* live with the other mocks,
-// but the build system will silently fail to import it in the development build
-// if it's outside the src/ directory
+/*
+ * This file is only used in development and *should* live in `tests/mocks/`,
+ * but the build system would silently fail to import it in the development
+ * build if it's outside the `src/` directory
+ */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
@@ -43,8 +45,10 @@ export const HEADERS: Record<string, string | string[]> = {
   "Access-Control-Allow-Origin": "*",
 } as const;
 
-// We need `any` in the type here to allow handlers to respond differently:
-// https://github.com/mswjs/msw/issues/377#issuecomment-690536532
+/*
+ * The RequestHandler type needs `any` so handlers can have different responses:
+ * https://github.com/mswjs/msw/issues/377#issuecomment-690536532
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handlers: RequestHandler<any, any, any, any>[] = [
   // Create a handler for each top level MOCK_DATA key; The handler for

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -1,7 +1,7 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 
-import { handlers, ENDPOINTS, MOCK_DATA } from "#server_routes.mock";
+import { handlers, ENDPOINTS, HEADERS, MOCK_DATA } from "#server_routes.mock";
 
 const server = setupServer(...handlers);
-export { rest, server, ENDPOINTS, MOCK_DATA };
+export { rest, server, ENDPOINTS, HEADERS, MOCK_DATA };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
       "#containers/*": ["src/containers/*"],
       "#test_helpers/*": ["tests/helpers/*"],
       "#types/*": ["types/*"],
+      "#api": ["src/api.ts"],
       "#api_endpoints": ["src/api_endpoints.ts"],
       "#server_routes.mock": ["src/server_routes.mock.ts"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "#src/*": ["src/*"],
       "#components/*": ["src/components/*"],
       "#containers/*": ["src/containers/*"],
+      "#layouts/*": ["src/layouts/*"],
       "#test_helpers/*": ["tests/helpers/*"],
       "#types/*": ["types/*"],
       "#api": ["src/api.ts"],


### PR DESCRIPTION
- Create `src/api.ts` to abstract API requests
- Use new API abstraction for existing pages
- Extract content of `/categories/` page to a pure function for easier testing
