### PR TITLE
Add Category page to render individual categories

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,6 +2,6 @@
 # https://docs.netlify.com/routing/redirects/
 
 # Never serve the raw category page from its root path
-/category/	/categories/	301!
+/category/	/404.html	404!
 # *Do* serve the category page for each specific category
 /categories/:name/	/category/index.html	200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,7 @@
+# This is a redirect file for Netlify
+# https://docs.netlify.com/routing/redirects/
+
+# Never serve the raw category page from its root path
+/category/	/categories/	301!
+# *Do* serve the category page for each specific category
+/categories/:name/	/category/index.html	200

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Router } from "@reach/router";
+import { Redirect, Router } from "@reach/router";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { setupWorker } from "msw"; // Dev usage only
 import React, { useState } from "react";
@@ -10,6 +10,7 @@ import { Nav } from "#components/Nav";
 import { handlers } from "#server_routes.mock"; // Dev usage only
 import Home from "./pages";
 import Categories from "./pages/categories";
+import Category from "./pages/category";
 import NotFound from "./pages/404";
 import { defaultTheme } from "./theme";
 import "./app.css";
@@ -80,6 +81,8 @@ export function App(): JSX.Element {
           <Router>
             <Home path="/" />
             <Categories path="categories/" />
+            <Category path="categories/:categoryName/" />
+            <Redirect from="category/" to="/categories/" />
             <NotFound default />
           </Router>
         </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Redirect, Router } from "@reach/router";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { setupWorker } from "msw"; // Dev usage only
 import React, { useState } from "react";
-import { Root } from "react-static";
+import { Root, addPrefetchExcludes } from "react-static";
 import { ThemeProvider, createGlobalStyle } from "styled-components";
 
 import { BurgerButton } from "#components/BurgerButton";
@@ -14,6 +14,9 @@ import Category from "./pages/category";
 import NotFound from "./pages/404";
 import { defaultTheme } from "./theme";
 import "./app.css";
+
+// Don't try to prefetch dynamic routes
+addPrefetchExcludes([/categories\/.+/]);
 
 // Mock the API server using a ServiceWorker
 if (
@@ -81,7 +84,7 @@ export function App(): JSX.Element {
           <Router>
             <Home path="/" />
             <Categories path="categories/" />
-            <Category path="categories/:categoryName/" />
+            <Category path="categories/:categorySlug/" />
             <Redirect from="category/" to="/categories/" />
             <NotFound default />
           </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Redirect, Router } from "@reach/router";
+import { Router } from "@reach/router";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { setupWorker } from "msw"; // Dev usage only
 import React, { useState } from "react";
@@ -85,7 +85,6 @@ export function App(): JSX.Element {
             <Home path="/" />
             <Categories path="categories/" />
             <Category path="categories/:categorySlug/" />
-            <Redirect from="category/" to="/categories/" />
             <NotFound default />
           </Router>
         </main>

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,12 +46,14 @@ function errorHandler(err: AxiosError): AxiosResponse {
    generic type or the clutter of defining each endpoint's type explicitly
 */
 export const api = {
-  getCategories: () =>
-    axios
+  getCategories() {
+    return axios
       .get<ICategories>(ENDPOINTS.categories)
-      .catch<AxiosResponse<ICategories>>(errorHandler),
-  getUsers: () =>
-    axios
+      .catch<AxiosResponse<ICategories>>(errorHandler);
+  },
+  getUsers() {
+    return axios
       .get<IUsers>(ENDPOINTS.users)
-      .catch<AxiosResponse<IUsers>>(errorHandler),
+      .catch<AxiosResponse<IUsers>>(errorHandler);
+  },
 } as const;

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,7 @@ import axiosRetry, {
 } from "axios-retry";
 
 import { ENDPOINTS } from "#api_endpoints";
-import type { ICategories, IUsers } from "#src/types";
+import type { ICategories, ICategory, IUsers } from "#src/types";
 
 export interface APIError extends AxiosError {
   uiErrorMessage: string;
@@ -51,6 +51,12 @@ export const api = {
       .get<ICategories>(ENDPOINTS.categories)
       .catch<AxiosResponse<ICategories>>(errorHandler);
   },
+  getCategoryBySlug(slug: string) {
+    return axios
+      .get<ICategory>(ENDPOINTS.category, { params: { slug } })
+      .catch<AxiosResponse<ICategory>>(errorHandler);
+  },
+
   getUsers() {
     return axios
       .get<IUsers>(ENDPOINTS.users)

--- a/src/api.ts
+++ b/src/api.ts
@@ -53,7 +53,7 @@ export const api = {
   },
   getCategoryBySlug(slug: string) {
     return axios
-      .get<ICategory>(ENDPOINTS.category, { params: { slug } })
+      .get<ICategory>(`${ENDPOINTS.categories}/${slug}`)
       .catch<AxiosResponse<ICategory>>(errorHandler);
   },
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,7 @@ import axiosRetry, {
 } from "axios-retry";
 
 import { ENDPOINTS } from "#api_endpoints";
-import type { ICategories, ICategory, IUsers } from "#src/types";
+import type { ICategories, ICategory, IInstruments, IUsers } from "#src/types";
 
 export interface APIError extends AxiosError {
   uiErrorMessage: string;
@@ -24,10 +24,9 @@ function errorHandler(err: AxiosError): AxiosResponse {
   let message: string;
 
   if (err.response) {
-    const { status, statusText } = err.response;
-    message =
-      `Error from server: "${status} ${statusText}".` +
-      " Please send a bug report!";
+    const { data, status, statusText } = err.response;
+    message = `Error from server: "${status} ${statusText}". `;
+    message += data?.error ?? "Please send a bug report!";
   } else if (err.request) {
     message = "Couldn't reach the server. Please try reloading in a minute.";
   } else {
@@ -55,6 +54,17 @@ export const api = {
     return axios
       .get<ICategory>(`${ENDPOINTS.categories}/${slug}`)
       .catch<AxiosResponse<ICategory>>(errorHandler);
+  },
+
+  getInstruments() {
+    return axios
+      .get<IInstruments>(ENDPOINTS.instruments)
+      .catch<AxiosResponse<IInstruments>>(errorHandler);
+  },
+  getInstrumentsByCategoryId(categoryId: number) {
+    return axios
+      .get<IInstruments>(ENDPOINTS.instruments, { params: { cat: categoryId } })
+      .catch<AxiosResponse<IInstruments>>(errorHandler);
   },
 
   getUsers() {

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -12,20 +12,20 @@ const { categories, users } = MOCK_DATA;
 
 type MethodTestSpec = readonly [
   method: keyof typeof api,
-  endpoint: keyof typeof ENDPOINTS,
+  endpoint: string,
   methodArgs: readonly unknown[],
   expected: unknown
 ];
 
 const HTTP_GET_ENDPOINTS: readonly MethodTestSpec[] = [
-  ["getCategories", "categories", [], { categories }],
+  ["getCategories", ENDPOINTS.categories, [], { categories }],
   [
     "getCategoryBySlug",
-    "category",
+    `${ENDPOINTS.categories}/winds`,
     ["winds"],
     categories.find(({ slug }) => slug === "winds"),
   ],
-  ["getUsers", "users", [], { users }],
+  ["getUsers", ENDPOINTS.users, [], { users }],
 ];
 
 describe("api", () => {
@@ -46,7 +46,7 @@ describe("api", () => {
       ".%s() returns a network error message if the error is persistent",
       (method, endpoint, args) => {
         server.use(
-          rest.get(ENDPOINTS[endpoint], (_req, res) => {
+          rest.get(endpoint, (_req, res) => {
             return res.networkError("Failed to connect");
           })
         );
@@ -69,7 +69,7 @@ describe("api", () => {
       ".%s() retries the request",
       async (method, endpoint, args, expected) => {
         server.use(
-          rest.get(ENDPOINTS[endpoint], (_req, res) => {
+          rest.get(endpoint, (_req, res) => {
             // TODO Return a NetworkError one time (the API doesn't exist yet):
             // https://github.com/mswjs/msw/issues/413
             return res.once(/* Do something */);
@@ -94,7 +94,7 @@ describe("api", () => {
       ".%s() returns a status error message if the error is persistent",
       (method, endpoint, args) => {
         server.use(
-          rest.get(ENDPOINTS[endpoint], (_req, res, ctx) => {
+          rest.get(endpoint, (_req, res, ctx) => {
             return res(ctx.set(HEADERS), ctx.status(500, "My Error"));
           })
         );
@@ -115,7 +115,7 @@ describe("api", () => {
       ".%s() retries the request",
       async (method, endpoint, args, expected) => {
         server.use(
-          rest.get(ENDPOINTS[endpoint], (_req, res, ctx) => {
+          rest.get(endpoint, (_req, res, ctx) => {
             return res.once(ctx.set(HEADERS), ctx.status(500, "My Error"));
           })
         );

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -8,25 +8,29 @@ import {
 import { api } from "#api";
 import type { APIError } from "#api";
 
+const { categories, users } = MOCK_DATA;
+
 type MethodTestSpec = readonly [
   method: keyof typeof api,
   endpoint: keyof typeof ENDPOINTS,
-  dataKey: keyof typeof MOCK_DATA
+  methodArgs: readonly unknown[],
+  expected: unknown
 ];
 
 const HTTP_GET_ENDPOINTS: readonly MethodTestSpec[] = [
-  ["getCategories", "categories", "categories"],
-  ["getUsers", "users", "users"],
+  ["getCategories", "categories", [], { categories }],
+  ["getUsers", "users", [], { users }],
 ];
 
 describe("api", () => {
   describe("given a successful API response", () => {
     test.each(HTTP_GET_ENDPOINTS)(
       '.%s() returns "%s" data',
-      async (method, _endpoint, dataKey) => {
-        const result = await api[method]();
+      async (method, _endpoint, args, expected) => {
+        // @ts-expect-error -- `args` may have different length/types
+        const result = await api[method](...args);
         expect(result).not.toHaveProperty("uiErrorMessage");
-        expect(result.data).toStrictEqual({ [dataKey]: MOCK_DATA[dataKey] });
+        expect(result.data).toStrictEqual(expected);
       }
     );
   });
@@ -34,7 +38,7 @@ describe("api", () => {
   describe("given a network error", () => {
     test.each(HTTP_GET_ENDPOINTS)(
       ".%s() returns a network error message if the error is persistent",
-      (method, endpoint) => {
+      (method, endpoint, args) => {
         server.use(
           rest.get(ENDPOINTS[endpoint], (_req, res) => {
             return res.networkError("Failed to connect");
@@ -43,18 +47,21 @@ describe("api", () => {
 
         expect.assertions(1);
 
-        return (api[method]() as Promise<unknown>).catch((err: APIError) => {
-          expect(err.uiErrorMessage).toStrictEqual(
-            "Couldn't reach the server. Please try reloading in a minute."
-          );
-        });
+        // @ts-expect-error -- `args` may have different length/types
+        return (api[method](...args) as Promise<unknown>).catch(
+          (err: APIError) => {
+            expect(err.uiErrorMessage).toStrictEqual(
+              "Couldn't reach the server. Please try reloading in a minute."
+            );
+          }
+        );
       }
     );
 
     // TODO Enable this test (remove `.skip`) when it's possible to implement it
     test.skip.each(HTTP_GET_ENDPOINTS)(
       ".%s() retries the request",
-      async (method, endpoint, dataKey) => {
+      async (method, endpoint, args, expected) => {
         server.use(
           rest.get(ENDPOINTS[endpoint], (_req, res) => {
             // TODO Return a NetworkError one time (the API doesn't exist yet):
@@ -66,8 +73,9 @@ describe("api", () => {
         expect.assertions(1);
 
         try {
-          const { data } = await api[method]();
-          expect(data).toStrictEqual({ [dataKey]: MOCK_DATA[dataKey] });
+          // @ts-expect-error -- `args` may have different length/types
+          const { data } = await api[method](...args);
+          expect(data).toStrictEqual(expected);
         } catch (err) {
           expect(err).not.toBeDefined();
         }
@@ -78,7 +86,7 @@ describe("api", () => {
   describe("given a 500 status code", () => {
     test.each(HTTP_GET_ENDPOINTS)(
       ".%s() returns a status error message if the error is persistent",
-      (method, endpoint) => {
+      (method, endpoint, args) => {
         server.use(
           rest.get(ENDPOINTS[endpoint], (_req, res, ctx) => {
             return res(ctx.set(HEADERS), ctx.status(500, "My Error"));
@@ -86,17 +94,20 @@ describe("api", () => {
         );
 
         expect.assertions(1);
-        return (api[method]() as Promise<unknown>).catch((err: APIError) => {
-          expect(err.uiErrorMessage).toStrictEqual(
-            'Error from server: "500 My Error". Please send a bug report!'
-          );
-        });
+        // @ts-expect-error -- `args` may have different length/types
+        return (api[method](...args) as Promise<unknown>).catch(
+          (err: APIError) => {
+            expect(err.uiErrorMessage).toStrictEqual(
+              'Error from server: "500 My Error". Please send a bug report!'
+            );
+          }
+        );
       }
     );
 
     test.each(HTTP_GET_ENDPOINTS)(
       ".%s() retries the request",
-      async (method, endpoint, dataKey) => {
+      async (method, endpoint, args, expected) => {
         server.use(
           rest.get(ENDPOINTS[endpoint], (_req, res, ctx) => {
             return res.once(ctx.set(HEADERS), ctx.status(500, "My Error"));
@@ -106,8 +117,9 @@ describe("api", () => {
         expect.assertions(1);
 
         try {
-          const { data } = await api[method]();
-          expect(data).toStrictEqual({ [dataKey]: MOCK_DATA[dataKey] });
+          // @ts-expect-error -- `args` may have different length/types
+          const { data } = await api[method](...args);
+          expect(data).toStrictEqual(expected);
         } catch (err) {
           expect(err).not.toBeDefined();
         }

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -19,6 +19,12 @@ type MethodTestSpec = readonly [
 
 const HTTP_GET_ENDPOINTS: readonly MethodTestSpec[] = [
   ["getCategories", "categories", [], { categories }],
+  [
+    "getCategoryBySlug",
+    "category",
+    ["winds"],
+    categories.find(({ slug }) => slug === "winds"),
+  ],
   ["getUsers", "users", [], { users }],
 ];
 

--- a/src/api_endpoints.ts
+++ b/src/api_endpoints.ts
@@ -2,5 +2,6 @@ const { API_ROOT } = process.env;
 
 export const ENDPOINTS = {
   categories: `${API_ROOT}/categories`,
+  category: `${API_ROOT}/category`,
   users: `${API_ROOT}/users/all`,
 } as const;

--- a/src/api_endpoints.ts
+++ b/src/api_endpoints.ts
@@ -2,5 +2,6 @@ const { API_ROOT } = process.env;
 
 export const ENDPOINTS = {
   categories: `${API_ROOT}/categories`,
+  instruments: `${API_ROOT}/instruments`,
   users: `${API_ROOT}/users/all`,
 } as const;

--- a/src/api_endpoints.ts
+++ b/src/api_endpoints.ts
@@ -2,6 +2,5 @@ const { API_ROOT } = process.env;
 
 export const ENDPOINTS = {
   categories: `${API_ROOT}/categories`,
-  category: `${API_ROOT}/category`,
   users: `${API_ROOT}/users/all`,
 } as const;

--- a/src/components/CategoryDetail.tsx
+++ b/src/components/CategoryDetail.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import type { ICategory } from "#src/types";
+
+export type CategoryDetailProps = Pick<
+  ICategory,
+  "name" | "summary" | "description"
+>;
+
+export function CategoryDetail({
+  name,
+  summary,
+  description,
+}: CategoryDetailProps): JSX.Element {
+  return (
+    <>
+      <h2>{name}</h2>
+      <p>{summary}</p>
+      <p>{description}</p>
+    </>
+  );
+}

--- a/src/components/CategoryDetail.unit.test.tsx
+++ b/src/components/CategoryDetail.unit.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { CategoryDetail } from "./CategoryDetail";
+
+describe("<CateogryDetail />", () => {
+  describe("given required props", () => {
+    it("renders the provided props", () => {
+      render(
+        <CategoryDetail
+          name="Foo"
+          summary="My Foo summary"
+          description="My description of Foo"
+        />
+      );
+      expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+        "Foo"
+      );
+      expect(screen.getByText("My Foo summary")).toBeInTheDocument();
+      expect(screen.getByText("My description of Foo")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/InstrumentList.tsx
+++ b/src/components/InstrumentList.tsx
@@ -1,0 +1,23 @@
+import React, { Fragment } from "react";
+
+import { InstrumentListItem } from "./InstrumentListItem";
+import type { InstrumentListItemProps } from "./InstrumentListItem";
+
+export interface InstrumentListProps {
+  instruments: InstrumentListItemProps[];
+}
+
+export function InstrumentList({
+  instruments,
+}: InstrumentListProps): JSX.Element {
+  return (
+    <>
+      {instruments.map(({ id, name, summary }, index) => (
+        <Fragment key={id}>
+          {index > 0 ? <hr /> : undefined}
+          <InstrumentListItem id={id} name={name} summary={summary} />
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/components/InstrumentList.unit.test.tsx
+++ b/src/components/InstrumentList.unit.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { InstrumentList } from "./InstrumentList";
+import type { InstrumentListProps } from "./InstrumentList";
+
+type ArrayElementType<T> = T extends (infer U)[] ? U : never;
+type Instrument = ArrayElementType<InstrumentListProps["instruments"]>;
+
+const INSTRUMENT1: Instrument = {
+  id: 0,
+  name: "Foo",
+  summary: "Foo summary",
+};
+
+const INSTRUMENT2: Instrument = {
+  id: 1,
+  name: "Bar",
+  summary: "Bar summary",
+};
+
+describe("<InstrumentList />", () => {
+  describe("given 1 instrument object", () => {
+    it("renders the instrument's data", () => {
+      render(<InstrumentList instruments={[INSTRUMENT1]} />);
+      expect(screen.getByText(INSTRUMENT1.summary)).toBeInTheDocument();
+    });
+  });
+
+  describe("given 2 instrument objects", () => {
+    it("renders both instruments' data", () => {
+      render(<InstrumentList instruments={[INSTRUMENT1, INSTRUMENT2]} />);
+      expect(screen.getByText(INSTRUMENT1.summary)).toBeInTheDocument();
+      expect(screen.getByText(INSTRUMENT2.summary)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/InstrumentListItem.tsx
+++ b/src/components/InstrumentListItem.tsx
@@ -1,0 +1,25 @@
+import { Link } from "@reach/router";
+import React from "react";
+
+import type { IInstrument } from "#src/types";
+
+export type InstrumentListItemProps = Pick<
+  IInstrument,
+  "id" | "name" | "summary"
+>;
+
+export function InstrumentListItem({
+  id,
+  name,
+  summary,
+}: InstrumentListItemProps): JSX.Element {
+  const url = `/instruments/${id}/${encodeURIComponent(name)}/`;
+  return (
+    <section>
+      <h3>
+        <Link to={url}>{name}</Link>
+      </h3>
+      <p>{summary}</p>
+    </section>
+  );
+}

--- a/src/components/InstrumentListItem.unit.test.tsx
+++ b/src/components/InstrumentListItem.unit.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { InstrumentListItem } from "./InstrumentListItem";
+
+describe("<InstrumentListItem />", () => {
+  describe("given required props", () => {
+    it("renders the provided props", () => {
+      render(<InstrumentListItem id={7} name="Foo" summary="My Foo summary" />);
+
+      expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
+        "Foo"
+      );
+      expect(screen.getByText("My Foo summary")).toBeInTheDocument();
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        "/instruments/7/Foo/"
+      );
+    });
+  });
+
+  describe("given an instrument name containing spaces", () => {
+    it("URL-encodes spaces for the rendered link's href", () => {
+      render(<InstrumentListItem id={7} name="Foo Bar" summary="summary" />);
+
+      const link = screen.getByRole("link");
+      expect(link).toHaveTextContent("Foo Bar");
+      expect(link).toHaveAttribute("href", "/instruments/7/Foo%20Bar/");
+    });
+  });
+});

--- a/src/layouts/Categories.tsx
+++ b/src/layouts/Categories.tsx
@@ -18,15 +18,15 @@ export function Categories({
       {categories.length === 0 ? (
         <p>{loadingMessage}</p>
       ) : (
-        categories.map(({ name, itemCount, summary, description }, index) => (
-          <Fragment key={name}>
+        categories.map((category, index) => (
+          <Fragment key={category.name}>
             {index > 0 ? <hr /> : undefined}
             <Category
-              name={name}
-              itemCount={itemCount}
-              summary={summary}
-              description={description}
-              url={`/categories/${name.toLowerCase()}/`}
+              name={category.name}
+              itemCount={category.itemCount}
+              summary={category.summary}
+              description={category.description}
+              url={`/categories/${category.slug}/`}
             />
           </Fragment>
         ))

--- a/src/layouts/Categories.tsx
+++ b/src/layouts/Categories.tsx
@@ -26,7 +26,7 @@ export function Categories({
               itemCount={itemCount}
               summary={summary}
               description={description}
-              url={`/category/${name.toLowerCase()}/`}
+              url={`/categories/${name.toLowerCase()}/`}
             />
           </Fragment>
         ))

--- a/src/layouts/Categories.unit.test.tsx
+++ b/src/layouts/Categories.unit.test.tsx
@@ -7,6 +7,7 @@ import { Categories } from "./Categories";
 const MESSAGE = "I'm loading";
 
 const CATEGORY1: ICategory = {
+  id: 0,
   name: "Foo",
   slug: "foo",
   itemCount: 5,
@@ -15,6 +16,7 @@ const CATEGORY1: ICategory = {
 } as const;
 
 const CATEGORY2: ICategory = {
+  id: 1,
   name: "Bar",
   slug: "bar",
   itemCount: 7,

--- a/src/layouts/Categories.unit.test.tsx
+++ b/src/layouts/Categories.unit.test.tsx
@@ -8,6 +8,7 @@ const MESSAGE = "I'm loading";
 
 const CATEGORY1: ICategory = {
   name: "Foo",
+  slug: "foo",
   itemCount: 5,
   summary: "Foo summary",
   description: "A description of Foo",
@@ -15,6 +16,7 @@ const CATEGORY1: ICategory = {
 
 const CATEGORY2: ICategory = {
   name: "Bar",
+  slug: "bar",
   itemCount: 7,
   summary: "Bar summary",
   description: "A description of Bar",

--- a/src/layouts/Category.tsx
+++ b/src/layouts/Category.tsx
@@ -1,0 +1,52 @@
+/*
+ * This component intentionally lacks unit tests
+ * It has integration tests instead
+ */
+
+import React, { useEffect, useState } from "react";
+
+import { api } from "#api";
+import type { APIError } from "#api";
+import { CategoryDetail } from "#components/CategoryDetail";
+import { InstrumentList } from "#components/InstrumentList";
+import type { InstrumentListProps } from "#components/InstrumentList";
+import type { ICategory } from "#src/types";
+
+export type CategoryProps = Pick<
+  ICategory,
+  "id" | "name" | "summary" | "description"
+>;
+
+export function Category({
+  id,
+  name,
+  summary,
+  description,
+}: CategoryProps): JSX.Element {
+  const [loadingMessage, setLoadingMessage] = useState("...Loading");
+  const [instruments, setInstruments] = useState<
+    InstrumentListProps["instruments"]
+  >();
+
+  useEffect(() => {
+    api.getInstrumentsByCategoryId(id).then(
+      ({ data }) => {
+        setInstruments(data.instruments);
+      },
+      (err: APIError) => {
+        setLoadingMessage(err.uiErrorMessage);
+      }
+    );
+  }, [id]);
+
+  return (
+    <>
+      <CategoryDetail name={name} summary={summary} description={description} />
+      {instruments ? (
+        <InstrumentList instruments={instruments} />
+      ) : (
+        <p>{loadingMessage}</p>
+      )}
+    </>
+  );
+}

--- a/src/pages/category.tsx
+++ b/src/pages/category.tsx
@@ -2,29 +2,37 @@ import { useParams } from "@reach/router";
 import type { RouteComponentProps } from "@reach/router";
 import React, { useEffect, useState } from "react";
 
+import { api } from "#api";
 import NotFound from "#src/pages/404";
 
-function capitalize(str: string) {
-  return str.length === 0 ? "" : str[0].toUpperCase() + str.slice(1);
-}
-
 interface CategoryPageProps {
-  categoryName?: string;
+  categorySlug?: string;
 }
 
 export default function CategoryPage(_: RouteComponentProps): JSX.Element {
-  const { categoryName } = useParams() as CategoryPageProps;
+  const { categorySlug } = useParams() as CategoryPageProps;
   const [name, setName] = useState("");
   const [categoryExists, setCategoryExists] = useState(true);
-  const categories = ["strings", "winds", "percussion"];
 
   useEffect(() => {
-    if (categoryName && categories.includes(categoryName)) {
-      setName(capitalize(categoryName));
-    } else {
+    if (!categorySlug) {
       setCategoryExists(false);
+      return;
     }
+
+    api.getCategoryBySlug(categorySlug).then(
+      ({ data }) => {
+        setName(data.name);
+      },
+      () => {
+        setCategoryExists(false);
+      }
+    );
   }, []);
 
-  return categoryExists ? <h2>Category: {name}</h2> : <NotFound />;
+  if (!categoryExists) {
+    return <NotFound />;
+  }
+
+  return name ? <h2>Category: {name}</h2> : <p>...Loading</p>;
 }

--- a/src/pages/category.tsx
+++ b/src/pages/category.tsx
@@ -1,0 +1,30 @@
+import { useParams } from "@reach/router";
+import type { RouteComponentProps } from "@reach/router";
+import React, { useEffect, useState } from "react";
+
+import NotFound from "#src/pages/404";
+
+function capitalize(str: string) {
+  return str.length === 0 ? "" : str[0].toUpperCase() + str.slice(1);
+}
+
+interface CategoryPageProps {
+  categoryName?: string;
+}
+
+export default function CategoryPage(_: RouteComponentProps): JSX.Element {
+  const { categoryName } = useParams() as CategoryPageProps;
+  const [name, setName] = useState("");
+  const [categoryExists, setCategoryExists] = useState(true);
+  const categories = ["strings", "winds", "percussion"];
+
+  useEffect(() => {
+    if (categoryName && categories.includes(categoryName)) {
+      setName(capitalize(categoryName));
+    } else {
+      setCategoryExists(false);
+    }
+  }, []);
+
+  return categoryExists ? <h2>Category: {name}</h2> : <NotFound />;
+}

--- a/src/pages/category.tsx
+++ b/src/pages/category.tsx
@@ -4,6 +4,8 @@ import React, { useEffect, useState } from "react";
 
 import { api } from "#api";
 import type { APIError } from "#api";
+import { Category } from "#layouts/Category";
+import type { CategoryProps } from "#layouts/Category";
 import NotFound from "#src/pages/404";
 
 interface CategoryPageProps {
@@ -13,7 +15,7 @@ interface CategoryPageProps {
 export default function CategoryPage(_: RouteComponentProps): JSX.Element {
   const { categorySlug } = useParams() as CategoryPageProps;
   const [loadingMessage, setLoadingMessage] = useState("...Loading");
-  const [name, setName] = useState("");
+  const [category, setCategory] = useState<CategoryProps>();
   const [categoryExists, setCategoryExists] = useState(true);
 
   useEffect(() => {
@@ -24,7 +26,7 @@ export default function CategoryPage(_: RouteComponentProps): JSX.Element {
 
     api.getCategoryBySlug(categorySlug).then(
       ({ data }) => {
-        setName(data.name);
+        setCategory(data);
       },
       (err: APIError) => {
         if (err.response?.status === 404) {
@@ -34,11 +36,20 @@ export default function CategoryPage(_: RouteComponentProps): JSX.Element {
         }
       }
     );
-  }, []);
+  }, [categorySlug]);
 
   if (!categoryExists) {
     return <NotFound />;
   }
 
-  return name ? <h2>Category: {name}</h2> : <p>{loadingMessage}</p>;
+  return category ? (
+    <Category
+      id={category.id}
+      name={category.name}
+      summary={category.summary}
+      description={category.description}
+    />
+  ) : (
+    <p>{loadingMessage}</p>
+  );
 }

--- a/src/pages/category.tsx
+++ b/src/pages/category.tsx
@@ -3,6 +3,7 @@ import type { RouteComponentProps } from "@reach/router";
 import React, { useEffect, useState } from "react";
 
 import { api } from "#api";
+import type { APIError } from "#api";
 import NotFound from "#src/pages/404";
 
 interface CategoryPageProps {
@@ -11,6 +12,7 @@ interface CategoryPageProps {
 
 export default function CategoryPage(_: RouteComponentProps): JSX.Element {
   const { categorySlug } = useParams() as CategoryPageProps;
+  const [loadingMessage, setLoadingMessage] = useState("...Loading");
   const [name, setName] = useState("");
   const [categoryExists, setCategoryExists] = useState(true);
 
@@ -24,8 +26,12 @@ export default function CategoryPage(_: RouteComponentProps): JSX.Element {
       ({ data }) => {
         setName(data.name);
       },
-      () => {
-        setCategoryExists(false);
+      (err: APIError) => {
+        if (err.response?.status === 404) {
+          setCategoryExists(false);
+        } else {
+          setLoadingMessage(err.uiErrorMessage);
+        }
       }
     );
   }, []);
@@ -34,5 +40,5 @@ export default function CategoryPage(_: RouteComponentProps): JSX.Element {
     return <NotFound />;
   }
 
-  return name ? <h2>Category: {name}</h2> : <p>...Loading</p>;
+  return name ? <h2>Category: {name}</h2> : <p>{loadingMessage}</p>;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,13 +11,13 @@ export default function Home(_: RouteComponentProps): JSX.Element {
       <h2>Browse by category</h2>
       <Category
         name="Winds"
-        url="/category/winds/"
+        url="/categories/winds/"
         itemCount={1}
         summary="Move air, make noise"
       />
       <Category
         name="Percussion"
-        url="/category/percussion/"
+        url="/categories/percussion/"
         itemCount={300}
         summary="Hit stuff"
       />

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -13,7 +13,10 @@ import type { ICategory, IUser } from "./types";
 
 export { ENDPOINTS };
 
-export const MOCK_DATA = {
+export const MOCK_DATA: {
+  categories: readonly ICategory[];
+  users: readonly IUser[];
+} = {
   categories: [
     {
       name: "Winds",
@@ -36,12 +39,12 @@ export const MOCK_DATA = {
       summary: "Wobbling cords",
       description: "This is a longer description of stringed instruments.",
     },
-  ] as ICategory[],
+  ],
   users: [
     { name: "Frida Permissions", id: 777 },
     { name: "Nonny Mouse", id: 1337 },
     { name: "No Body", id: 12345 },
-  ] as IUser[],
+  ],
 } as const;
 
 export const HEADERS: Record<string, string | string[]> = {
@@ -54,12 +57,10 @@ export const HEADERS: Record<string, string | string[]> = {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handlers: RequestHandler<any, any, any, any>[] = [
-  // Create a handler for each top level MOCK_DATA key; The handler for
-  // a given key uses the URL defined in ENDPOINTS under the same key
-  ...(Object.keys(MOCK_DATA) as Array<keyof typeof MOCK_DATA>).map((key) => {
-    return rest.get(ENDPOINTS[key], (_req, res, ctx) => {
-      return res(ctx.set(HEADERS), ctx.json({ [key]: MOCK_DATA[key] }));
-    });
+  /** Handle: /categories */
+  rest.get(ENDPOINTS.categories, (_req, res, ctx) => {
+    const { categories } = MOCK_DATA;
+    return res(ctx.set(HEADERS), ctx.json({ categories }));
   }),
 
   /** Handle: /category?slug=<lowercase-category-name> */
@@ -70,5 +71,11 @@ export const handlers: RequestHandler<any, any, any, any>[] = [
     return category
       ? res(ctx.set(HEADERS), ctx.json(category))
       : res(ctx.set(HEADERS), ctx.status(404));
+  }),
+
+  /** Handle: /users */
+  rest.get(ENDPOINTS.users, (_req, res, ctx) => {
+    const { users } = MOCK_DATA;
+    return res(ctx.set(HEADERS), ctx.json({ users }));
   }),
 ];

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -57,23 +57,23 @@ export const HEADERS: Record<string, string | string[]> = {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handlers: RequestHandler<any, any, any, any>[] = [
-  /** Handle: /categories */
-  rest.get(ENDPOINTS.categories, (_req, res, ctx) => {
-    const { categories } = MOCK_DATA;
-    return res(ctx.set(HEADERS), ctx.json({ categories }));
-  }),
-
-  /** Handle: /category?slug=<lowercase-category-name> */
-  rest.get(ENDPOINTS.category, (req, res, ctx) => {
+  // GET Category: /categories/<category-slug>
+  rest.get(`${ENDPOINTS.categories}/:categorySlug`, (req, res, ctx) => {
     const category = MOCK_DATA.categories.find(
-      ({ slug }) => slug === req.url.searchParams.get("slug")
+      ({ slug }) => slug === req.params.categorySlug
     );
     return category
       ? res(ctx.set(HEADERS), ctx.json(category))
       : res(ctx.set(HEADERS), ctx.status(404));
   }),
 
-  /** Handle: /users */
+  // GET Categories: /categories
+  rest.get(ENDPOINTS.categories, (_req, res, ctx) => {
+    const { categories } = MOCK_DATA;
+    return res(ctx.set(HEADERS), ctx.json({ categories }));
+  }),
+
+  // GET Users: /users
   rest.get(ENDPOINTS.users, (_req, res, ctx) => {
     const { users } = MOCK_DATA;
     return res(ctx.set(HEADERS), ctx.json({ users }));

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -9,16 +9,18 @@ import { rest } from "msw";
 import type { RequestHandler } from "msw";
 
 import { ENDPOINTS } from "./api_endpoints";
-import type { ICategory, IUser } from "./types";
+import type { ICategory, IInstrument, IUser } from "./types";
 
 export { ENDPOINTS };
 
 export const MOCK_DATA: {
   categories: readonly ICategory[];
+  instruments: readonly IInstrument[];
   users: readonly IUser[];
 } = {
   categories: [
     {
+      id: 0,
       name: "Winds",
       slug: "winds",
       itemCount: 3,
@@ -26,6 +28,7 @@ export const MOCK_DATA: {
       description: "This is a longer description of wind instruments.",
     },
     {
+      id: 1,
       name: "Percussion",
       slug: "percussion",
       itemCount: 300,
@@ -33,11 +36,63 @@ export const MOCK_DATA: {
       description: "This is a longer description of percussion instruments.",
     },
     {
+      id: 2,
       name: "Strings",
       slug: "strings",
       itemCount: 72,
       summary: "Wobbling cords",
       description: "This is a longer description of stringed instruments.",
+    },
+  ],
+  instruments: [
+    {
+      id: 0,
+      categoryId: 0,
+      name: "Flute",
+      summary: "Flute summary",
+      description: "Long description of flutes.",
+    },
+    {
+      id: 1,
+      categoryId: 0,
+      name: "Clarinet",
+      summary: "Clarinet summary",
+      description: "Long description of clarinets.",
+    },
+    {
+      id: 2,
+      categoryId: 1,
+      name: "Timpani",
+      summary: "Timpani description",
+      description: "Long description of timpani.",
+    },
+    {
+      id: 3,
+      categoryId: 1,
+      name: "Marimba",
+      summary: "Marimba description",
+      description: "Long description of marimbas.",
+    },
+    {
+      id: 4,
+      categoryId: 2,
+      name: "Viola",
+      summary: "Viola summary",
+      description: "Long description of violas.",
+    },
+    {
+      id: 5,
+      categoryId: 2,
+      name: "Guitar",
+      summary: "Guitar summary",
+      description: "Long description of guitars.",
+    },
+    {
+      id: 6,
+      categoryId: 2,
+      name: "Harp",
+      summary: "Harp summary",
+      description: "Long description of harps.",
     },
   ],
   users: [
@@ -71,6 +126,28 @@ export const handlers: RequestHandler<any, any, any, any>[] = [
   rest.get(ENDPOINTS.categories, (_req, res, ctx) => {
     const { categories } = MOCK_DATA;
     return res(ctx.set(HEADERS), ctx.json({ categories }));
+  }),
+
+  // GET Instruments: /instruments[?cat=<categoryId>]
+  rest.get(ENDPOINTS.instruments, (req, res, ctx) => {
+    const reqCategoryId = req.url.searchParams.get("cat");
+
+    // By default, return all instruments
+    let { instruments } = MOCK_DATA;
+
+    // /instruments?cat=<categoryId>
+    if (reqCategoryId !== null) {
+      if (!/^[0-9]+$/.test(reqCategoryId)) {
+        const error = "Category ID must be an integer.";
+        return res(ctx.set(HEADERS), ctx.status(400), ctx.json({ error }));
+      }
+
+      instruments = instruments.filter(
+        ({ categoryId }) => categoryId === Number(reqCategoryId)
+      );
+    }
+
+    return res(ctx.set(HEADERS), ctx.json({ instruments }));
   }),
 
   // GET Users: /users

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -17,18 +17,21 @@ export const MOCK_DATA = {
   categories: [
     {
       name: "Winds",
+      slug: "winds",
       itemCount: 3,
       summary: "Move air, make noise",
       description: "This is a longer description of wind instruments.",
     },
     {
       name: "Percussion",
+      slug: "percussion",
       itemCount: 300,
       summary: "Hit stuff",
       description: "This is a longer description of percussion instruments.",
     },
     {
       name: "Strings",
+      slug: "strings",
       itemCount: 72,
       summary: "Wobbling cords",
       description: "This is a longer description of stringed instruments.",
@@ -57,5 +60,15 @@ export const handlers: RequestHandler<any, any, any, any>[] = [
     return rest.get(ENDPOINTS[key], (_req, res, ctx) => {
       return res(ctx.set(HEADERS), ctx.json({ [key]: MOCK_DATA[key] }));
     });
+  }),
+
+  /** Handle: /category?slug=<lowercase-category-name> */
+  rest.get(ENDPOINTS.category, (req, res, ctx) => {
+    const category = MOCK_DATA.categories.find(
+      ({ slug }) => slug === req.url.searchParams.get("slug")
+    );
+    return category
+      ? res(ctx.set(HEADERS), ctx.json(category))
+      : res(ctx.set(HEADERS), ctx.status(404));
   }),
 ];

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -63,14 +63,14 @@ export const MOCK_DATA: {
       id: 2,
       categoryId: 1,
       name: "Timpani",
-      summary: "Timpani description",
+      summary: "Timpani summary",
       description: "Long description of timpani.",
     },
     {
       id: 3,
       categoryId: 1,
       name: "Marimba",
-      summary: "Marimba description",
+      summary: "Marimba summary",
       description: "Long description of marimbas.",
     },
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface ICategory {
   name: string;
+  slug: string;
   itemCount: number;
   summary: string;
   description: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface ICategory {
+  id: number;
   name: string;
   slug: string;
   itemCount: number;
@@ -8,6 +9,18 @@ export interface ICategory {
 
 export interface ICategories {
   categories: ICategory[];
+}
+
+export interface IInstrument {
+  id: number;
+  categoryId: number;
+  name: string;
+  summary: string;
+  description: string;
+}
+
+export interface IInstruments {
+  instruments: IInstrument[];
 }
 
 export interface IUser {

--- a/tests/integration/routes.int.test.tsx
+++ b/tests/integration/routes.int.test.tsx
@@ -62,7 +62,7 @@ describe("<App />", () => {
   describe("given the route '/categories/strings/' and a server error", () => {
     it("displays an error message", async () => {
       server.use(
-        rest.get(ENDPOINTS.category, (_req, res, ctx) => {
+        rest.get(`${ENDPOINTS.categories}/strings`, (_req, res, ctx) => {
           return res(ctx.set(HEADERS), ctx.status(500, "Server error"));
         })
       );

--- a/tests/integration/routes.int.test.tsx
+++ b/tests/integration/routes.int.test.tsx
@@ -52,10 +52,8 @@ describe("<App />", () => {
       const heading2 = await screen.findByRole("heading", { level: 2 });
       expect(heading2).toHaveTextContent(/strings/i);
 
-      // Wait for the AJAX request to finish before unmounting to avoid an error
-      await waitFor(() => {
-        expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
-      });
+      // Wait for AJAX requests to finish before unmounting to avoid an error
+      await screen.findAllByRole("heading", { level: 3 });
     });
   });
 

--- a/tests/integration/routes.int.test.tsx
+++ b/tests/integration/routes.int.test.tsx
@@ -1,15 +1,8 @@
 import { screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { setupServer } from "msw/node";
 
 import { App } from "#src/App";
 import { renderWithRouter } from "../helpers/renderWithRouter";
-import { handlers } from "#server_routes.mock";
-
-const server = setupServer(...handlers);
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
 
 describe("<App />", () => {
   describe("given the route '/'", () => {
@@ -29,6 +22,14 @@ describe("<App />", () => {
     });
   });
 
+  describe("given the route '/does-not-exist/'", () => {
+    it("displays the 404 error page", () => {
+      renderWithRouter(<App />, "/does-not-exist/");
+      const heading2 = screen.getByRole("heading", { level: 2 });
+      expect(heading2).toHaveTextContent(/404/i);
+    });
+  });
+
   describe("given the route '/categories/'", () => {
     it("displays content from Categories page", async () => {
       renderWithRouter(<App />, "/categories/");
@@ -40,14 +41,6 @@ describe("<App />", () => {
       await waitFor(() => {
         expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
       });
-    });
-  });
-
-  describe("given the route '/does-not-exist/'", () => {
-    it("displays the 404 error page", () => {
-      renderWithRouter(<App />, "/does-not-exist/");
-      const heading2 = screen.getByRole("heading", { level: 2 });
-      expect(heading2).toHaveTextContent(/404/i);
     });
   });
 });


### PR DESCRIPTION
In addition to adding the Category page, some notable changes included in this PR are:

- Combine API endpoint `/category` into `/categories`
    - individual categories are now queried at `/categories/<category-slug>`
- Add API endpoint `/instruments` which accepts a query parameter `?cat=<categoryId>`
- Refactor api unit tests to support method parameters
