### PR TITLE
Add Instrument page for /instruments/:id/:name/ route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,15 +8,16 @@ import { ThemeProvider, createGlobalStyle } from "styled-components";
 import { BurgerButton } from "#components/BurgerButton";
 import { Nav } from "#components/Nav";
 import { handlers } from "#server_routes.mock"; // Dev usage only
-import NotFound from "./pages/404";
 import HomePage from "./pages";
+import NotFound from "./pages/404";
 import CategoriesPage from "./pages/categories";
 import CategoryPage from "./pages/category";
+import InstrumentPage from "./pages/instrument";
 import { defaultTheme } from "./theme";
 import "./app.css";
 
 // Don't try to prefetch dynamic routes
-addPrefetchExcludes([/categories\/.+/]);
+addPrefetchExcludes([/categories\/.+/, /instruments\/.+/]);
 
 // Mock the API server using a ServiceWorker
 if (
@@ -85,6 +86,7 @@ export function App(): JSX.Element {
             <HomePage path="/" />
             <CategoriesPage path="categories/" />
             <CategoryPage path="categories/:categorySlug/" />
+            <InstrumentPage path="instruments/:instrumentId/**" />
             <NotFound default />
           </Router>
         </main>

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,13 @@ import axiosRetry, {
 } from "axios-retry";
 
 import { ENDPOINTS } from "#api_endpoints";
-import type { ICategories, ICategory, IInstruments, IUsers } from "#src/types";
+import type {
+  ICategories,
+  ICategory,
+  IInstrument,
+  IInstruments,
+  IUsers,
+} from "#src/types";
 
 export interface APIError extends AxiosError {
   uiErrorMessage: string;
@@ -65,6 +71,11 @@ export const api = {
     return axios
       .get<IInstruments>(ENDPOINTS.instruments, { params: { cat: categoryId } })
       .catch<AxiosResponse<IInstruments>>(errorHandler);
+  },
+  getInstrumentById(id: number) {
+    return axios
+      .get<IInstrument>(`${ENDPOINTS.instruments}/${id}`)
+      .catch<AxiosResponse<IInstrument>>(errorHandler);
   },
 
   getUsers() {

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -32,13 +32,19 @@ const HTTP_GET_ENDPOINTS: readonly MethodTestSpec[] = [
     [1],
     { instruments: instruments.filter(({ categoryId }) => categoryId === 1) },
   ],
+  [
+    "getInstrumentById",
+    `${ENDPOINTS.instruments}/2`,
+    [2],
+    instruments.find(({ id }) => id === 2),
+  ],
   ["getUsers", ENDPOINTS.users, [], { users }],
 ];
 
 describe("api", () => {
   describe("given a successful API response", () => {
     test.each(HTTP_GET_ENDPOINTS)(
-      '.%s() returns "%s" data',
+      '.%s() returns data from "%s"',
       async (method, _endpoint, args, expected) => {
         // @ts-expect-error -- `args` may have different length/types
         const result = await api[method](...args);

--- a/src/app.css
+++ b/src/app.css
@@ -31,6 +31,7 @@ a {
 
 img {
   max-width: 100%;
+  max-height: 100%;
 }
 
 nav {

--- a/src/layouts/Instrument/Instrument.tsx
+++ b/src/layouts/Instrument/Instrument.tsx
@@ -1,23 +1,73 @@
 import React from "react";
+import styled from "styled-components";
 
 import type { IInstrument } from "#src/types";
 
+const imgMaxWidth = "400px";
+const imgMaxHeight = "600px";
+
+const InstrumentContainer = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+
+  .img-container {
+    order: -1;
+    flex: 0 0 auto;
+    width: 50vw;
+    max-width: ${imgMaxWidth};
+    max-height: ${imgMaxHeight};
+  }
+
+  h2 {
+    flex: 1;
+    margin: 1em;
+    text-align: center;
+    font-size: 2em;
+  }
+
+  h2 ~ * {
+    flex-basis: 100%;
+  }
+
+  @media (min-width: ${({ theme }) => theme.mobileBreakpoint}) {
+    display: block;
+
+    h2 {
+      margin: 0 0 1.5rem;
+    }
+
+    .img-container {
+      float: left;
+      margin-right: 1rem;
+      margin-bottom: 1rem;
+      width: ${imgMaxWidth};
+      max-width: none;
+      max-height: none;
+    }
+  }
+`;
+
 export type InstrumentProps = Pick<
   IInstrument,
-  "name" | "summary" | "description"
+  "name" | "summary" | "description" | "imageUrl"
 >;
 
 export function Instrument({
   name,
   summary,
   description,
+  imageUrl,
 }: InstrumentProps): JSX.Element {
   return (
-    <>
+    <InstrumentContainer>
       <h2>{name}</h2>
+      <div className="img-container">
+        <img src={imageUrl} alt={name} />
+      </div>
       <p>{summary}</p>
       <hr />
       <p>{description}</p>
-    </>
+    </InstrumentContainer>
   );
 }

--- a/src/layouts/Instrument/Instrument.tsx
+++ b/src/layouts/Instrument/Instrument.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import type { IInstrument } from "#src/types";
+
+export type InstrumentProps = Pick<
+  IInstrument,
+  "name" | "summary" | "description"
+>;
+
+export function Instrument({
+  name,
+  summary,
+  description,
+}: InstrumentProps): JSX.Element {
+  return (
+    <>
+      <h2>{name}</h2>
+      <p>{summary}</p>
+      <hr />
+      <p>{description}</p>
+    </>
+  );
+}

--- a/src/layouts/Instrument/Instrument.unit.test.tsx
+++ b/src/layouts/Instrument/Instrument.unit.test.tsx
@@ -11,11 +11,17 @@ describe("<Instrument />", () => {
           name="Foo"
           summary="My Foo summary"
           description="My description of Foo"
+          imageUrl="http://foo.com/"
         />
       );
-      expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
-        "Foo"
-      );
+
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("src", "http://foo.com/");
+      expect(img).toHaveAttribute("alt", "Foo");
+
+      const heading2 = screen.getByRole("heading", { level: 2 });
+      expect(heading2).toHaveTextContent("Foo");
+
       expect(screen.getByText("My Foo summary")).toBeInTheDocument();
       expect(screen.getByText("My description of Foo")).toBeInTheDocument();
     });

--- a/src/layouts/Instrument/Instrument.unit.test.tsx
+++ b/src/layouts/Instrument/Instrument.unit.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { Instrument } from "./Instrument";
+
+describe("<Instrument />", () => {
+  describe("given required props", () => {
+    it("renders the provided props", () => {
+      render(
+        <Instrument
+          name="Foo"
+          summary="My Foo summary"
+          description="My description of Foo"
+        />
+      );
+      expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+        "Foo"
+      );
+      expect(screen.getByText("My Foo summary")).toBeInTheDocument();
+      expect(screen.getByText("My description of Foo")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/layouts/Instrument/index.tsx
+++ b/src/layouts/Instrument/index.tsx
@@ -1,0 +1,2 @@
+export { Instrument } from "./Instrument";
+export type { InstrumentProps } from "./Instrument";

--- a/src/pages/category.tsx
+++ b/src/pages/category.tsx
@@ -5,8 +5,8 @@ import React, { useEffect, useState } from "react";
 import { api } from "#api";
 import type { APIError } from "#api";
 import { Category } from "#layouts/Category";
-import type { CategoryProps } from "#layouts/Category";
 import NotFound from "#src/pages/404";
+import type { ICategory } from "#src/types";
 
 interface CategoryPageProps {
   categorySlug?: string;
@@ -15,28 +15,32 @@ interface CategoryPageProps {
 export default function CategoryPage(_: RouteComponentProps): JSX.Element {
   const { categorySlug } = useParams() as CategoryPageProps;
   const [loadingMessage, setLoadingMessage] = useState("...Loading");
-  const [category, setCategory] = useState<CategoryProps>();
+  const [category, setCategory] = useState<ICategory>();
   const [categoryExists, setCategoryExists] = useState(true);
 
   useEffect(() => {
     if (!categorySlug) {
       setCategoryExists(false);
-      return;
-    }
+    } else if (!category || category.slug !== categorySlug) {
+      // Reset the state before fetching new instrument data
+      setLoadingMessage("...Loading");
+      setCategory(undefined);
+      setCategoryExists(true); // Hide 404 unless we *know* it doesn't exist
 
-    api.getCategoryBySlug(categorySlug).then(
-      ({ data }) => {
-        setCategory(data);
-      },
-      (err: APIError) => {
-        if (err.response?.status === 404) {
-          setCategoryExists(false);
-        } else {
-          setLoadingMessage(err.uiErrorMessage);
+      api.getCategoryBySlug(categorySlug).then(
+        ({ data }) => {
+          setCategory(data);
+        },
+        (err: APIError) => {
+          if (err.response?.status === 404) {
+            setCategoryExists(false);
+          } else {
+            setLoadingMessage(err.uiErrorMessage);
+          }
         }
-      }
-    );
-  }, [categorySlug]);
+      );
+    }
+  }, [categorySlug, category]);
 
   if (!categoryExists) {
     return <NotFound />;

--- a/src/pages/instrument.tsx
+++ b/src/pages/instrument.tsx
@@ -1,0 +1,67 @@
+import { useNavigate, useParams } from "@reach/router";
+import type { RouteComponentProps } from "@reach/router";
+import React, { useEffect, useState } from "react";
+
+import { api } from "#api";
+import type { APIError } from "#api";
+import type { IInstrument } from "#src/types";
+import NotFound from "#src/pages/404";
+
+interface InstrumentPageProps {
+  instrumentId: string; // An integer, but the router passes it as a string
+}
+
+/**
+ * This page's path: /instruments/<instrumentId>/<instrumentName>/
+ *
+ * - e.g. /instruments/4/Double%20Bass/
+ * - `instrumentId` is canonical
+ * - `instrumentName` helps with readability and SEO, but it can be changed
+ *
+ * The URL will be updated if `instrumentName` is missing or incorrect, so both
+ * /instruments/4/ and /instruments/4/wrongname/ will be correctly redirected
+ */
+export default function InstrumentPage(_: RouteComponentProps): JSX.Element {
+  const { instrumentId } = useParams() as InstrumentPageProps;
+  const [loadingMessage, setLoadingMessage] = useState("...Loading");
+  const [instrument, setInstrument] = useState<IInstrument>();
+  const [instrumentExists, setInstrumentExists] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!instrumentId.match(/^[0-9]+$/)) {
+      setInstrumentExists(false);
+    } else if (instrument && instrument.id === Number(instrumentId)) {
+      // Make sure the URL reflects the correct instrument name & ends with "/"
+      const encodedName = encodeURIComponent(instrument.name);
+      const canonicalPath = `/instruments/${instrument.id}/${encodedName}/`;
+      if (window.location.pathname !== canonicalPath) {
+        navigate(canonicalPath, { replace: true });
+      }
+    } else {
+      // Reset the state before fetching new instrument data
+      setLoadingMessage("...Loading");
+      setInstrument(undefined);
+      setInstrumentExists(true); // Hide 404 unless we *know* it doesn't exist
+
+      api.getInstrumentById(Number(instrumentId)).then(
+        ({ data }) => {
+          setInstrument(data);
+        },
+        (err: APIError) => {
+          if (err.response?.status === 404) {
+            setInstrumentExists(false);
+          } else {
+            setLoadingMessage(err.uiErrorMessage);
+          }
+        }
+      );
+    }
+  }, [instrumentId, instrument, window.location.pathname]);
+
+  if (!instrumentExists) {
+    return <NotFound />;
+  }
+
+  return instrument ? <h2>{instrument.name}</h2> : <p>{loadingMessage}</p>;
+}

--- a/src/pages/instrument.tsx
+++ b/src/pages/instrument.tsx
@@ -69,6 +69,7 @@ export default function InstrumentPage(_: RouteComponentProps): JSX.Element {
       name={instrument.name}
       summary={instrument.summary}
       description={instrument.description}
+      imageUrl={instrument.imageUrl}
     />
   ) : (
     <p>{loadingMessage}</p>

--- a/src/pages/instrument.tsx
+++ b/src/pages/instrument.tsx
@@ -4,8 +4,9 @@ import React, { useEffect, useState } from "react";
 
 import { api } from "#api";
 import type { APIError } from "#api";
-import type { IInstrument } from "#src/types";
+import { Instrument } from "#layouts/Instrument";
 import NotFound from "#src/pages/404";
+import type { IInstrument } from "#src/types";
 
 interface InstrumentPageProps {
   instrumentId: string; // An integer, but the router passes it as a string
@@ -63,5 +64,13 @@ export default function InstrumentPage(_: RouteComponentProps): JSX.Element {
     return <NotFound />;
   }
 
-  return instrument ? <h2>{instrument.name}</h2> : <p>{loadingMessage}</p>;
+  return instrument ? (
+    <Instrument
+      name={instrument.name}
+      summary={instrument.summary}
+      description={instrument.description}
+    />
+  ) : (
+    <p>{loadingMessage}</p>
+  );
 }

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -51,6 +51,8 @@ export const MOCK_DATA: {
       name: "Flute",
       summary: "Flute summary",
       description: "Long description of flutes.",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Western_concert_flute_%28Yamaha%29.jpg/442px-Western_concert_flute_%28Yamaha%29.jpg",
     },
     {
       id: 1,
@@ -58,6 +60,8 @@ export const MOCK_DATA: {
       name: "Clarinet",
       summary: "Clarinet summary",
       description: "Long description of clarinets.",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Clarinet-rotate.png/466px-Clarinet-rotate.png",
     },
     {
       id: 2,
@@ -65,6 +69,8 @@ export const MOCK_DATA: {
       name: "Timpani",
       summary: "Timpani summary",
       description: "Long description of timpani.",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a8/HardtkePauken.jpg/640px-HardtkePauken.jpg",
     },
     {
       id: 3,
@@ -72,6 +78,8 @@ export const MOCK_DATA: {
       name: "Marimba",
       summary: "Marimba summary",
       description: "Long description of marimbas.",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2d/Classical_Marimba_player.jpg/640px-Classical_Marimba_player.jpg",
     },
     {
       id: 4,
@@ -79,6 +87,8 @@ export const MOCK_DATA: {
       name: "Double Bass",
       summary: "Double bass summary",
       description: "Long description of double basses.",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Leandre_Gramss_double_double_bass_05.jpg/400px-Leandre_Gramss_double_double_bass_05.jpg",
     },
     {
       id: 5,
@@ -86,6 +96,8 @@ export const MOCK_DATA: {
       name: "Guitar",
       summary: "Guitar summary",
       description: "Long description of guitars.",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Front_of_a_finished_Doc_Watson_Gallagher_guitar.jpg/400px-Front_of_a_finished_Doc_Watson_Gallagher_guitar.jpg",
     },
     {
       id: 6,
@@ -93,6 +105,8 @@ export const MOCK_DATA: {
       name: "Harp",
       summary: "Harp summary",
       description: "Long description of harps.",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Pedal_Harp_MET_DT698.jpg/412px-Pedal_Harp_MET_DT698.jpg",
     },
   ],
   users: [

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -128,6 +128,16 @@ export const handlers: RequestHandler<any, any, any, any>[] = [
     return res(ctx.set(HEADERS), ctx.json({ categories }));
   }),
 
+  // GET Instrument: /instruments/<instrumentId>
+  rest.get(`${ENDPOINTS.instruments}/:id`, (req, res, ctx) => {
+    const instrument = MOCK_DATA.instruments.find(
+      ({ id }) => id === Number(req.params.id)
+    );
+    return instrument
+      ? res(ctx.set(HEADERS), ctx.json(instrument))
+      : res(ctx.set(HEADERS), ctx.status(404));
+  }),
+
   // GET Instruments: /instruments[?cat=<categoryId>]
   rest.get(ENDPOINTS.instruments, (req, res, ctx) => {
     const reqCategoryId = req.url.searchParams.get("cat");

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -76,9 +76,9 @@ export const MOCK_DATA: {
     {
       id: 4,
       categoryId: 2,
-      name: "Viola",
-      summary: "Viola summary",
-      description: "Long description of violas.",
+      name: "Double Bass",
+      summary: "Double bass summary",
+      description: "Long description of double basses.",
     },
     {
       id: 5,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface IInstrument {
   name: string;
   summary: string;
   description: string;
+  imageUrl: string;
 }
 
 export interface IInstruments {

--- a/tests/integration/category.int.test.tsx
+++ b/tests/integration/category.int.test.tsx
@@ -1,0 +1,44 @@
+import { screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { App } from "#src/App";
+import { renderWithRouter } from "../helpers/renderWithRouter";
+
+function waitForPageLoad() {
+  return waitFor(() => {
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
+}
+
+describe("src/pages/category.tsx rendered inside <App />", () => {
+  describe("given a navigation from an invalid path to a valid path", () => {
+    // This would fail if the component's state were not reset when navigating
+    it("renders data for the valid path", async () => {
+      const { history } = renderWithRouter(<App />, "/categories/badPath/");
+      await waitForPageLoad();
+      await history.navigate("/categories/winds/");
+
+      await waitFor(() => {
+        const heading2 = screen.queryByRole("heading", { level: 2 });
+        expect(heading2).toHaveTextContent(/winds/i);
+      });
+
+      await waitForPageLoad(); // Wait for AJAX request to finish
+    });
+  });
+
+  describe("given a navigation from one valid path to another", () => {
+    it("renders data for the second path", async () => {
+      const { history } = renderWithRouter(<App />, "/categories/winds/");
+      await waitForPageLoad();
+      await history.navigate("/categories/strings/");
+
+      await waitFor(() => {
+        const heading2 = screen.queryByRole("heading", { level: 2 });
+        expect(heading2).toHaveTextContent(/strings/i);
+      });
+
+      await waitForPageLoad(); // Wait for AJAX request to finish
+    });
+  });
+});

--- a/tests/integration/category.int.test.tsx
+++ b/tests/integration/category.int.test.tsx
@@ -28,6 +28,7 @@ describe("src/pages/category.tsx rendered inside <App />", () => {
   });
 
   describe("given a navigation from one valid path to another", () => {
+    // This would fail if the component's state were not reset when navigating
     it("renders data for the second path", async () => {
       const { history } = renderWithRouter(<App />, "/categories/winds/");
       await waitForPageLoad();

--- a/tests/integration/instrument.int.test.tsx
+++ b/tests/integration/instrument.int.test.tsx
@@ -68,4 +68,17 @@ describe("src/pages/instrument.tsx rendered inside <App />", () => {
       });
     });
   });
+
+  describe("given a navigation from one valid path to another", () => {
+    it("renders data for the second path", async () => {
+      const { history } = renderWithRouter(<App />, "/instruments/0/Flute/");
+      await waitForPageLoad();
+      await history.navigate("/instruments/4/Double%20Bass/");
+
+      await waitFor(() => {
+        const heading2 = screen.queryByRole("heading", { level: 2 });
+        expect(heading2).toHaveTextContent(/double bass/i);
+      });
+    });
+  });
 });

--- a/tests/integration/instrument.int.test.tsx
+++ b/tests/integration/instrument.int.test.tsx
@@ -70,6 +70,7 @@ describe("src/pages/instrument.tsx rendered inside <App />", () => {
   });
 
   describe("given a navigation from one valid path to another", () => {
+    // This would fail if the component's state were not reset when navigating
     it("renders data for the second path", async () => {
       const { history } = renderWithRouter(<App />, "/instruments/0/Flute/");
       await waitForPageLoad();

--- a/tests/integration/instrument.int.test.tsx
+++ b/tests/integration/instrument.int.test.tsx
@@ -1,0 +1,71 @@
+import { screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { App } from "#src/App";
+import { renderWithRouter } from "../helpers/renderWithRouter";
+
+function waitForPageLoad() {
+  return waitFor(() => {
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
+}
+
+describe("src/pages/instrument.tsx rendered inside <App />", () => {
+  describe("given the canonical path for an instrument", () => {
+    const paths = ["/instruments/0/Flute/", "/instruments/4/Double%20Bass/"];
+
+    it.each(paths)("does not modify the path %s", async (path) => {
+      const { history } = renderWithRouter(<App />, path);
+      await waitForPageLoad();
+      expect(history.location.pathname).toBe(path);
+    });
+  });
+
+  describe("given missing or extra characters in a path", () => {
+    const canonicalPath = "/instruments/0/Flute/";
+    const redirectablePaths = [
+      "/instruments/0",
+      "/instruments/0/",
+      "/instruments/0/Flute",
+      "/instruments/0/Flute/foo/",
+    ];
+
+    it.each(redirectablePaths)(
+      `redirects %s to ${canonicalPath}`,
+      async (path) => {
+        const { history } = renderWithRouter(<App />, path);
+        await waitForPageLoad();
+        expect(history.location.pathname).toBe(canonicalPath);
+      }
+    );
+  });
+
+  describe("given a non-existent instrument ID", () => {
+    const badPaths = [
+      "/instruments/Flute/",
+      "/instruments/-2/",
+      "/instruments/7000/", // Can exist, but it's not in our mock data
+    ];
+
+    it.each(badPaths)("displays the 404 error page for %s", async (path) => {
+      renderWithRouter(<App />, path);
+      await waitForPageLoad();
+      const heading2 = screen.getByRole("heading", { level: 2 });
+      expect(heading2).toHaveTextContent(/404/i);
+    });
+  });
+
+  describe("given a navigation from an invalid path to a valid path", () => {
+    // This would fail if the component's state were not reset when navigating
+    it("renders data for the valid path", async () => {
+      const { history } = renderWithRouter(<App />, "/instruments/badPath/");
+      await waitForPageLoad();
+      await history.navigate("/instruments/0/Flute/");
+
+      await waitFor(() => {
+        const heading2 = screen.queryByRole("heading", { level: 2 });
+        expect(heading2).toHaveTextContent(/flute/i);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Add api method: `getInstrumentById()`
- Add route and content for Instrument pages
