### PR TITLE
Implement request cancellation for API requests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,9 @@ module.exports = {
   },
 
   rules: {
+    // Let TypeScript handle validating return values
+    "consistent-return": "off",
+
     // Be explicit when an import is only used as a type
     "@typescript-eslint/consistent-type-imports": ["error"],
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist/
 /tmp/
 .env
+tsconfig.tsbuildinfo

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,12 @@ process.env.FRONTEND_MOCK_API_SERVER = "false";
 module.exports = {
   preset: "ts-jest",
 
+  globals: {
+    "ts-jest": {
+      isolatedModules: true,
+    },
+  },
+
   moduleNameMapper: {
     // Use import paths as defined in tsconfig.json
     ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>/" }),

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -1,185 +1,469 @@
+import { rest, server, HEADERS, MOCK_DATA } from "#test_helpers/server";
 import {
-  rest,
-  server,
-  ENDPOINTS,
-  HEADERS,
-  MOCK_DATA,
-} from "#test_helpers/server";
-import { api } from "#api";
-import type { APIError } from "#api";
+  baseRequest,
+  getCategories,
+  getCategoryBySlug,
+  getInstruments,
+  getInstrumentsByCategoryId,
+  getInstrumentById,
+  getUsers,
+} from "#api";
+import type { APIHandlers, APIUtils, RequestParams } from "#api";
 
-const { categories, instruments, users } = MOCK_DATA;
+const { API_ROOT } = process.env;
 
-type MethodTestSpec = readonly [
-  method: keyof typeof api,
-  endpoint: string,
-  methodArgs: readonly unknown[],
-  expected: any // eslint-disable-line @typescript-eslint/no-explicit-any
-];
+describe("baseRequest()", () => {
+  function callBaseRequest(params: RequestParams) {
+    const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+    const { cancel, completed } = baseRequest(handlers, params);
+    return { ...handlers, cancel, completed };
+  }
 
-const HTTP_GET_ENDPOINTS: readonly MethodTestSpec[] = [
-  ["getCategories", ENDPOINTS.categories, [], { categories }],
-  [
-    "getCategoryBySlug",
-    `${ENDPOINTS.categories}/winds`,
-    ["winds"],
-    categories.find(({ slug }) => slug === "winds"),
-  ],
-  ["getInstruments", ENDPOINTS.instruments, [], { instruments }],
-  [
-    "getInstrumentsByCategoryId",
-    ENDPOINTS.instruments,
-    [1],
-    { instruments: instruments.filter(({ categoryId }) => categoryId === 1) },
-  ],
-  [
-    "getInstrumentById",
-    `${ENDPOINTS.instruments}/2`,
-    [2],
-    instruments.find(({ id }) => id === 2),
-  ],
-  ["getUsers", ENDPOINTS.users, [], { users }],
-];
-
-describe("api", () => {
   describe("given a successful API response", () => {
-    test.each(HTTP_GET_ENDPOINTS)(
-      '.%s() returns data from "%s"',
-      async (method, _endpoint, args, expected) => {
-        // @ts-expect-error -- `args` may have different length/types
-        const result = await api[method](...args);
-        expect(result).not.toHaveProperty("uiErrorMessage");
-        expect(result.data).toStrictEqual(expected);
-      }
-    );
+    it("calls onSuccess() with the response data", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        rest.get(url, (_req, res, ctx) => {
+          return res(ctx.json({ foo: "bar" }));
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
+
+      expect(request.onSuccess).toBeCalledWith({ foo: "bar" });
+      expect(request.onError).not.toBeCalled();
+    });
+  });
+
+  describe("given a call to cancel() before the request completes", () => {
+    it("does not call onSuccess() or onError()", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        rest.get(url, (_req, res, ctx) => {
+          return res(ctx.json({ foo: "bar" }));
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      request.cancel();
+      await request.completed;
+
+      expect(request.onSuccess).not.toBeCalled();
+      expect(request.onError).not.toBeCalled();
+    });
+  });
+
+  describe("given a call to cancel() after the request completes", () => {
+    it("calling cancel() does not throw", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        rest.get(url, (_req, res, ctx) => {
+          return res(ctx.json({ foo: "bar" }));
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
+
+      expect(() => request.cancel()).not.toThrow();
+      expect(request.onSuccess).toBeCalledWith({ foo: "bar" });
+      expect(request.onError).not.toBeCalled();
+    });
   });
 
   describe("given a network error", () => {
-    test.each(HTTP_GET_ENDPOINTS)(
-      ".%s() returns a network error message if the error is persistent",
-      (method, endpoint, args) => {
+    it("calls onError() with a network error message if the error is persistent", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        rest.get(url, (_req, res) => {
+          return res.networkError("Failed to connect");
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
+
+      expect(request.onSuccess).not.toBeCalled();
+      expect(request.onError).toBeCalledTimes(1);
+
+      const [uiErrorMessage] = request.onError.mock.calls[0];
+      expect(uiErrorMessage).toStrictEqual(
+        "Couldn't reach the server. Please try reloading in a minute."
+      );
+    });
+
+    it.skip("retries the request", async () => {
+      const url = `${API_ROOT}/api-test`;
+      // TODO Use a builtin msw method to return a NetworkError once, after msw
+      // implements such a method -- https://github.com/mswjs/msw/issues/413
+      // For now, this workaround does the trick
+      function enableSuccessfulApiResponse() {
         server.use(
-          rest.get(endpoint, (_req, res) => {
-            return res.networkError("Failed to connect");
+          rest.get(url, (_req, res, ctx) => {
+            return res(ctx.json({ foo: "bar" }));
           })
         );
-
-        expect.assertions(1);
-
-        // @ts-expect-error -- `args` may have different length/types
-        return (api[method](...args) as Promise<unknown>).catch(
-          (err: APIError) => {
-            expect(err.uiErrorMessage).toStrictEqual(
-              "Couldn't reach the server. Please try reloading in a minute."
-            );
-          }
-        );
       }
-    );
+      server.use(
+        rest.get(url, (_req, res) => {
+          enableSuccessfulApiResponse();
+          return res.networkError("Failed to connect");
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
 
-    // TODO Enable this test (remove `.skip`) when it's possible to implement it
-    test.skip.each(HTTP_GET_ENDPOINTS)(
-      ".%s() retries the request",
-      async (method, endpoint, args, expected) => {
-        server.use(
-          rest.get(endpoint, (_req, res) => {
-            // TODO Return a NetworkError one time (the API doesn't exist yet):
-            // https://github.com/mswjs/msw/issues/413
-            return res.once(/* Do something */);
-          })
-        );
-
-        expect.assertions(1);
-
-        try {
-          // @ts-expect-error -- `args` may have different length/types
-          const { data } = await api[method](...args);
-          expect(data).toStrictEqual(expected);
-        } catch (err) {
-          expect(err).not.toBeDefined();
-        }
-      }
-    );
+      // console.log(request.onError.mock.calls[0][1].toJSON());
+      expect(request.onError).not.toBeCalled();
+      expect(request.onSuccess).toBeCalledWith({ foo: "bar" });
+    });
   });
 
   describe("given a 500 status code", () => {
-    test.each(HTTP_GET_ENDPOINTS)(
-      ".%s() returns a status error message if the error is persistent",
-      (method, endpoint, args) => {
-        server.use(
-          rest.get(endpoint, (_req, res, ctx) => {
-            return res(ctx.set(HEADERS), ctx.status(500, "My Error"));
-          })
-        );
+    it("calls onError() with a status error message if the error is persistent", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        rest.get(url, (_req, res, ctx) => {
+          return res(ctx.status(500, "My Error"));
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
 
-        expect.assertions(1);
-        // @ts-expect-error -- `args` may have different length/types
-        return (api[method](...args) as Promise<unknown>).catch(
-          (err: APIError) => {
-            expect(err.uiErrorMessage).toStrictEqual(
-              'Error from server: "500 My Error". Please send a bug report!'
-            );
-          }
-        );
-      }
-    );
+      expect(request.onSuccess).not.toBeCalled();
+      expect(request.onError).toBeCalledTimes(1);
 
-    test.each(HTTP_GET_ENDPOINTS)(
-      ".%s() retries the request",
-      async (method, endpoint, args, expected) => {
-        server.use(
-          rest.get(endpoint, (_req, res, ctx) => {
-            return res.once(ctx.set(HEADERS), ctx.status(500, "My Error"));
-          })
-        );
+      const [uiErrorMessage] = request.onError.mock.calls[0];
+      expect(uiErrorMessage).toStrictEqual(
+        'Error from server: "500 My Error". Please send a bug report!'
+      );
+    });
 
-        expect.assertions(1);
+    it("retries the request", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        // Return a 500 status once
+        rest.get(url, (_req, res, ctx) => {
+          return res.once(ctx.status(500, "My Error"));
+        }),
+        // Then return a successful response
+        rest.get(url, (_req, res, ctx) => {
+          return res(ctx.json({ foo: "bar" }));
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
 
-        try {
-          // @ts-expect-error -- `args` may have different length/types
-          const { data } = await api[method](...args);
-          expect(data).toStrictEqual(expected);
-        } catch (err) {
-          expect(err).not.toBeDefined();
-        }
-      }
-    );
+      expect(request.onSuccess).toBeCalledWith({ foo: "bar" });
+      expect(request.onError).not.toBeCalled();
+    });
   });
 
   describe("given a 400 status code and a JSON error message", () => {
-    test.each(HTTP_GET_ENDPOINTS)(
-      ".%s() returns a status error message including the JSON error message",
-      (method, endpoint, args) => {
+    it("calls onError() with a status error message including the JSON message", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        rest.get(url, (_req, res, ctx) => {
+          return res(
+            ctx.status(400, "My Error"),
+            ctx.json({ error: "My Special Error" })
+          );
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
+
+      expect(request.onSuccess).not.toBeCalled();
+      expect(request.onError).toBeCalledTimes(1);
+
+      const [uiErrorMessage] = request.onError.mock.calls[0];
+      expect(uiErrorMessage).toStrictEqual(
+        'Error from server: "400 My Error". My Special Error'
+      );
+    });
+
+    it("does not retry the request", async () => {
+      const url = `${API_ROOT}/api-test`;
+      server.use(
+        // Return a 400 status once
+        rest.get(url, (_req, res, ctx) => {
+          return res.once(
+            ctx.status(400, "My Error"),
+            ctx.json({ error: "My Special Error" })
+          );
+        }),
+        // Then return a successful response
+        rest.get(url, (_req, res, ctx) => {
+          return res(ctx.json({ foo: "bar" }));
+        })
+      );
+      const request = callBaseRequest({ method: "GET", url });
+      await request.completed;
+
+      expect(request.onSuccess).not.toBeCalled();
+      expect(request.onError).toBeCalledTimes(1);
+
+      const [uiErrorMessage] = request.onError.mock.calls[0];
+      expect(uiErrorMessage).toStrictEqual(
+        'Error from server: "400 My Error". My Special Error'
+      );
+    });
+  });
+
+  /*
+   * NOTE: We're not testing `getUiErrorMessage()`'s "Unknown error" branch.
+   *
+   * I'm not sure how to trigger that branch with real request behavior. If I
+   * knew, it wouldn't be an unknown error and we could provide a better
+   * message. We *could* unit test `getUiErrorMessage()` with an object lacking
+   * `.response` and `.request`, but that would just be testing JavaScript's
+   * `else` keyword, it wouldn't provide any confidence about app behavior.
+   */
+});
+
+const apiFunctions: [string, (handlers: APIHandlers<unknown>) => APIUtils][] = [
+  ["getCategories", (handlers) => getCategories(handlers)],
+  ["getCategoryBySlug", (handlers) => getCategoryBySlug("strings", handlers)],
+  ["getInstruments", (handlers) => getInstruments(handlers)],
+  [
+    "getInstrumentsByCategoryId",
+    (handlers) => getInstrumentsByCategoryId(2, handlers),
+  ],
+  ["getInstrumentById", (handlers) => getInstrumentById(4, handlers)],
+  ["getUsers", (handlers) => getUsers(handlers)],
+];
+
+describe("API functions", () => {
+  describe("given a 400 status code", () => {
+    test.each(apiFunctions)(
+      "%s() calls onError() with a status error message",
+      async (_name, fn) => {
         server.use(
-          rest.get(endpoint, (_req, res, ctx) => {
-            return res(
-              ctx.set(HEADERS),
-              ctx.status(400, "My Error"),
-              ctx.json({ error: "My Special Error" })
+          rest.get(`${API_ROOT}/*`, (_req, res, ctx) => {
+            return res.once(
+              ctx.status(400, "Status Error"),
+              ctx.json({ error: "JSON Error" })
             );
           })
         );
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { completed } = fn(handlers);
+        await completed;
 
-        expect.assertions(1);
-        // @ts-expect-error -- `args` may have different length/types
-        return (api[method](...args) as Promise<unknown>).catch(
-          (err: APIError) => {
-            expect(err.uiErrorMessage).toStrictEqual(
-              'Error from server: "400 My Error". My Special Error'
-            );
-          }
+        expect(handlers.onSuccess).not.toBeCalled();
+        expect(handlers.onError).toBeCalledTimes(1);
+
+        const [uiErrorMessage] = handlers.onError.mock.calls[0];
+        expect(uiErrorMessage).toStrictEqual(
+          'Error from server: "400 Status Error". JSON Error'
         );
       }
     );
   });
 
-  /*
-   * NOTE: We're not testing `errorHandler()`'s "Unknown error" branch.
-   *
-   * I'm not sure how to trigger that branch with real request behavior. If I
-   * knew, it wouldn't be an unknown error and we could provide a better
-   * message. We could unit test `errorHandler()` with an object lacking
-   * `.response` and `.request`, but that would just be testing JavaScript's
-   * `else` keyword, it wouldn't provide any confidence about app behavior.
-   */
+  describe("given a call to cancel() before the request completes", () => {
+    test.each(apiFunctions)(
+      "%s() does not call onSuccess() or onError()",
+      async (_name, fn) => {
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { cancel, completed } = fn(handlers);
+        cancel();
+        await completed;
+
+        expect(handlers.onSuccess).not.toBeCalled();
+        expect(handlers.onError).not.toBeCalled();
+      }
+    );
+  });
+});
+
+describe("getCategories()", () => {
+  describe("given a successful API response", () => {
+    it("calls onSuccess() with the expected data", async () => {
+      const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+      const { completed } = getCategories(handlers);
+      await completed;
+
+      const { categories } = MOCK_DATA;
+      expect(handlers.onSuccess).toBeCalledWith({ categories });
+      expect(handlers.onError).not.toBeCalled();
+    });
+  });
+});
+
+describe("getCategoryBySlug()", () => {
+  describe("given an existing category's slug", () => {
+    it.each(["strings", "winds"])(
+      'calls onSuccess() with the expected data for category "%s"',
+      async (categorySlug) => {
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const request = getCategoryBySlug(categorySlug, handlers);
+        await request.completed;
+
+        const category = MOCK_DATA.categories.find(
+          ({ slug }) => slug === categorySlug
+        );
+        expect(category).not.toEqual(undefined);
+        expect(handlers.onSuccess).toBeCalledWith(category);
+        expect(handlers.onError).not.toBeCalled();
+      }
+    );
+  });
+
+  describe("given a non-existent category name", () => {
+    it("calls onError() with a 404 error message", async () => {
+      const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+      const { completed } = getCategoryBySlug("not-a-thing", handlers);
+      await completed;
+
+      expect(handlers.onSuccess).not.toBeCalled();
+      expect(handlers.onError).toBeCalledTimes(1);
+
+      const [uiErrorMessage, error] = handlers.onError.mock
+        .calls[0] as Parameters<APIHandlers<unknown>["onError"]>;
+      expect(uiErrorMessage).toMatch(/Error from server: "404/);
+      expect(error.response?.status).toStrictEqual(404);
+    });
+  });
+
+  describe("given an empty string", () => {
+    it("calls onError() with an error message", async () => {
+      const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+      const { completed } = getCategoryBySlug("", handlers);
+      await completed;
+
+      expect(handlers.onSuccess).not.toBeCalled();
+      expect(handlers.onError).toBeCalledTimes(1);
+
+      const [uiErrorMessage] = handlers.onError.mock.calls[0] as Parameters<
+        APIHandlers<unknown>["onError"]
+      >;
+      expect(uiErrorMessage).toMatch(/Error from server/);
+    });
+  });
+});
+
+describe("getInstruments()", () => {
+  describe("given a successful API response", () => {
+    it("calls onSuccess() with the expected data", async () => {
+      const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+      const { completed } = getInstruments(handlers);
+      await completed;
+
+      const { instruments } = MOCK_DATA;
+      expect(handlers.onSuccess).toBeCalledWith({ instruments });
+      expect(handlers.onError).not.toBeCalled();
+    });
+  });
+});
+
+describe("getInstrumentsByCategoryId()", () => {
+  describe("given an existing category ID", () => {
+    it.each([0, 2])(
+      "calls onSuccess() with the expected data for ID %d",
+      async (id) => {
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const request = getInstrumentsByCategoryId(id, handlers);
+        await request.completed;
+
+        const instruments = MOCK_DATA.instruments.filter(
+          ({ categoryId }) => categoryId === id
+        );
+        expect(handlers.onSuccess).toBeCalledWith({ instruments });
+        expect(handlers.onError).not.toBeCalled();
+      }
+    );
+  });
+
+  describe("given a non-existent category ID", () => {
+    it("calls onSuccess() with an empty array of instruments", async () => {
+      const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+      const { completed } = getInstrumentsByCategoryId(9001, handlers);
+      await completed;
+
+      expect(handlers.onSuccess).toBeCalledWith({ instruments: [] });
+      expect(handlers.onError).not.toBeCalled();
+    });
+  });
+
+  describe("given an invalid category ID", () => {
+    it.each([-1, 1.1, NaN, Infinity])(
+      "calls onError() with an error message for ID %d",
+      async (id) => {
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { completed } = getInstrumentsByCategoryId(id, handlers);
+        await completed;
+
+        expect(handlers.onSuccess).not.toBeCalled();
+        expect(handlers.onError).toBeCalledTimes(1);
+
+        const [uiErrorMessage] = handlers.onError.mock.calls[0];
+        expect(uiErrorMessage).toMatch(/Error from server/);
+      }
+    );
+  });
+});
+
+describe("getInstrumentById()", () => {
+  describe("given an existing ID", () => {
+    it.each([0, 4])(
+      "calls onSuccess() with the expected data for ID %d",
+      async (instrumentId) => {
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const request = getInstrumentById(instrumentId, handlers);
+        await request.completed;
+
+        const instrument = MOCK_DATA.instruments.find(
+          ({ id }) => id === instrumentId
+        );
+        expect(instrument).not.toEqual(undefined);
+        expect(handlers.onSuccess).toBeCalledWith(instrument);
+        expect(handlers.onError).not.toBeCalled();
+      }
+    );
+  });
+
+  describe("given a non-existent ID", () => {
+    it("calls onError() with a 404 error message", async () => {
+      const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+      const { completed } = getInstrumentById(1337, handlers);
+      await completed;
+
+      expect(handlers.onSuccess).not.toBeCalled();
+      expect(handlers.onError).toBeCalledTimes(1);
+
+      const [uiErrorMessage, error] = handlers.onError.mock
+        .calls[0] as Parameters<APIHandlers<unknown>["onError"]>;
+      expect(uiErrorMessage).toMatch(/Error from server: "404/);
+      expect(error.response?.status).toStrictEqual(404);
+    });
+  });
+
+  describe("given an invalid ID", () => {
+    it.each([-1, 1.1, NaN, Infinity])(
+      "calls onError() with an error message for ID %d",
+      async (id) => {
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { completed } = getInstrumentById(id, handlers);
+        await completed;
+
+        expect(handlers.onSuccess).not.toBeCalled();
+        expect(handlers.onError).toBeCalledTimes(1);
+
+        const [uiErrorMessage] = handlers.onError.mock.calls[0];
+        expect(uiErrorMessage).toMatch(/Error from server/);
+      }
+    );
+  });
+});
+
+describe("getUsers()", () => {
+  describe("given a successful API response", () => {
+    it("calls onSuccess() with the expected data", async () => {
+      const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+      const { completed } = getUsers(handlers);
+      await completed;
+
+      const { users } = MOCK_DATA;
+      expect(handlers.onSuccess).toBeCalledWith({ users });
+      expect(handlers.onError).not.toBeCalled();
+    });
+  });
 });

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -1,4 +1,5 @@
-import { rest, server, HEADERS, MOCK_DATA } from "#test_helpers/server";
+/** @jest-environment node */
+import { rest, server, MOCK_DATA } from "#test_helpers/server";
 import {
   baseRequest,
   getCategories,
@@ -89,7 +90,7 @@ describe("baseRequest()", () => {
       );
     });
 
-    it.skip("retries the request", async () => {
+    it("retries the request", async () => {
       const url = `${API_ROOT}/api-test`;
       // TODO Use a builtin msw method to return a NetworkError once, after msw
       // implements such a method -- https://github.com/mswjs/msw/issues/413

--- a/src/api_endpoints.ts
+++ b/src/api_endpoints.ts
@@ -3,5 +3,5 @@ const { API_ROOT } = process.env;
 export const ENDPOINTS = {
   categories: `${API_ROOT}/categories`,
   instruments: `${API_ROOT}/instruments`,
-  users: `${API_ROOT}/users/all`,
+  users: `${API_ROOT}/users`,
 } as const;

--- a/src/components/ApiDiv/ApiDiv.tsx
+++ b/src/components/ApiDiv/ApiDiv.tsx
@@ -1,20 +1,16 @@
 import React, { useEffect, useState } from "react";
 
-import { api } from "#api";
-import type { APIError } from "#api";
+import { getUsers } from "#api";
 
 export function ApiDiv(): JSX.Element {
   const [content, setContent] = useState("...Loading");
 
   useEffect(() => {
-    api.getUsers().then(
-      ({ data }) => {
-        setContent(`Users: ${JSON.stringify(data)}`);
-      },
-      (err: APIError) => {
-        setContent(err.uiErrorMessage);
-      }
-    );
+    const { cancel } = getUsers({
+      onSuccess: ({ users }) => setContent(`Users: ${JSON.stringify(users)}`),
+      onError: (uiErrorMessage) => setContent(uiErrorMessage),
+    });
+    return cancel;
   }, []);
 
   return <div>{content}</div>;

--- a/src/components/ApiDiv/ApiDiv.unit.test.tsx
+++ b/src/components/ApiDiv/ApiDiv.unit.test.tsx
@@ -23,7 +23,9 @@ describe("<ApiDiv />", () => {
   describe("given failed API call", () => {
     it("displays failure message", async () => {
       server.use(
-        rest.get(ENDPOINTS.users, (_req, res) => res.networkError("Net fail"))
+        rest.get(`${ENDPOINTS.users}/all`, (_req, res) => {
+          return res.networkError("Net fail");
+        })
       );
       render(<ApiDiv />);
       await screen.findByText(/couldn't reach the server/i);

--- a/src/layouts/Category/Category.tsx
+++ b/src/layouts/Category/Category.tsx
@@ -1,12 +1,11 @@
-/*
- * This component intentionally lacks unit tests
- * It has integration tests instead
+/**
+ * This component intentionally lacks unit tests (all behavior is delegated)
+ * It's covered by integration tests instead
  */
 
 import React, { useEffect, useState } from "react";
 
-import { api } from "#api";
-import type { APIError } from "#api";
+import { getInstrumentsByCategoryId } from "#api";
 import { CategoryDetail } from "#components/CategoryDetail";
 import { InstrumentList } from "#components/InstrumentList";
 import type { InstrumentListProps } from "#components/InstrumentList";
@@ -29,14 +28,16 @@ export function Category({
   >();
 
   useEffect(() => {
-    api.getInstrumentsByCategoryId(id).then(
-      ({ data }) => {
-        setInstruments(data.instruments);
-      },
-      (err: APIError) => {
-        setLoadingMessage(err.uiErrorMessage);
-      }
-    );
+    // Reset state
+    setLoadingMessage("...Loading");
+    setInstruments(undefined);
+
+    const { cancel } = getInstrumentsByCategoryId(id, {
+      onSuccess: (data) => setInstruments(data.instruments),
+      onError: (uiErrorMessage) => setLoadingMessage(uiErrorMessage),
+    });
+
+    return cancel;
   }, [id]);
 
   return (

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -1,8 +1,7 @@
 import type { RouteComponentProps } from "@reach/router";
 import React, { useEffect, useState } from "react";
 
-import { api } from "#api";
-import type { APIError } from "#api";
+import { getCategories } from "#api";
 import { Categories } from "#layouts/Categories";
 import type { ICategory } from "#src/types";
 
@@ -11,8 +10,8 @@ export default function CategoriesPage(_: RouteComponentProps): JSX.Element {
   const [loadingMessage, setLoadingMessage] = useState("...Loading");
 
   useEffect(() => {
-    api.getCategories().then(
-      ({ data }) => {
+    const { cancel } = getCategories({
+      onSuccess(data) {
         if (data.categories.length > 0) {
           setCategories(data.categories);
           setLoadingMessage("");
@@ -20,10 +19,12 @@ export default function CategoriesPage(_: RouteComponentProps): JSX.Element {
           setLoadingMessage("No categories have been defined yet.");
         }
       },
-      (err: APIError) => {
-        setLoadingMessage(err.uiErrorMessage);
-      }
-    );
+      onError(uiErrorMessage) {
+        setLoadingMessage(uiErrorMessage);
+      },
+    });
+
+    return cancel;
   }, []);
 
   return <Categories categories={categories} loadingMessage={loadingMessage} />;

--- a/tests/helpers/renderWithRouter.tsx
+++ b/tests/helpers/renderWithRouter.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import type { RenderResult } from "@testing-library/react";
 import {
   LocationProvider,
   createHistory,
@@ -13,7 +14,7 @@ import type { History } from "@reach/router";
 export function renderWithRouter(
   component: JSX.Element,
   route = "/"
-): { history: History } {
+): RenderResult & { history: History } {
   const history = createHistory(createMemorySource(route));
   return {
     ...render(

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -1,7 +1,7 @@
-import { rest } from "msw";
 import { setupServer } from "msw/node";
 
-import { handlers, ENDPOINTS, HEADERS, MOCK_DATA } from "#server_routes.mock";
+import { handlers } from "#server_routes.mock";
 
-const server = setupServer(...handlers);
-export { rest, server, ENDPOINTS, HEADERS, MOCK_DATA };
+export { rest } from "msw";
+export { ENDPOINTS, MOCK_DATA } from "#server_routes.mock";
+export const server = setupServer(...handlers);

--- a/tests/integration/category.int.test.tsx
+++ b/tests/integration/category.int.test.tsx
@@ -14,42 +14,60 @@ jest.mock("@auth0/auth0-react", () => ({
 // and the page content we're testing doesn't depend on being authenticated
 useAuth.mockReturnValue(LOADING);
 
-function waitForPageLoad() {
-  return waitFor(() => {
-    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+describe("<CategoryPage /> rendered inside <App />", () => {
+  describe("given the path /categories/percussion/", () => {
+    it("renders data for the category and its instruments", async () => {
+      renderWithRouter(<App />, "/categories/percussion/");
+
+      // Category data is rendered
+      const heading2 = await screen.findByRole("heading", { level: 2 });
+      expect(heading2).toHaveTextContent(/Percussion/);
+
+      // Instruments for the category are rendered (with values from mock data)
+      const headings3 = await screen.findAllByRole("heading", { level: 3 });
+      expect(headings3).toHaveLength(2);
+      expect(headings3[0]).toHaveTextContent("Timpani");
+      expect(headings3[1]).toHaveTextContent("Marimba");
+    });
   });
-}
 
-describe("src/pages/category.tsx rendered inside <App />", () => {
   describe("given a navigation from an invalid path to a valid path", () => {
-    // This would fail if the component's state were not reset when navigating
     it("renders data for the valid path", async () => {
-      const { history } = renderWithRouter(<App />, "/categories/badPath/");
-      await waitForPageLoad();
-      await history.navigate("/categories/winds/");
+      const { history, unmount } = renderWithRouter(
+        <App />,
+        "/categories/badPath/"
+      );
 
-      await waitFor(() => {
-        const heading2 = screen.queryByRole("heading", { level: 2 });
-        expect(heading2).toHaveTextContent(/winds/i);
-      });
+      // Invalid path
+      const heading2Invalid = await screen.findByRole("heading", { level: 2 });
+      expect(heading2Invalid).toHaveTextContent(/404/);
 
-      await waitForPageLoad(); // Wait for AJAX request to finish
+      // Valid path
+      await waitFor(() => history.navigate("/categories/winds/"));
+      const heading2Valid = await screen.findByRole("heading", { level: 2 });
+      expect(heading2Valid).toHaveTextContent(/Winds/);
+
+      unmount();
     });
   });
 
   describe("given a navigation from one valid path to another", () => {
-    // This would fail if the component's state were not reset when navigating
     it("renders data for the second path", async () => {
-      const { history } = renderWithRouter(<App />, "/categories/winds/");
-      await waitForPageLoad();
-      await history.navigate("/categories/strings/");
+      const { history, unmount } = renderWithRouter(
+        <App />,
+        "/categories/winds/"
+      );
 
-      await waitFor(() => {
-        const heading2 = screen.queryByRole("heading", { level: 2 });
-        expect(heading2).toHaveTextContent(/strings/i);
-      });
+      // First valid path
+      const heading2Winds = await screen.findByRole("heading", { level: 2 });
+      expect(heading2Winds).toHaveTextContent(/Winds/);
 
-      await waitForPageLoad(); // Wait for AJAX request to finish
+      // Second valid path
+      await waitFor(() => history.navigate("/categories/strings/"));
+      const heading2Strings = await screen.findByRole("heading", { level: 2 });
+      expect(heading2Strings).toHaveTextContent(/Strings/);
+
+      unmount();
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "baseUrl": ".",
     "esModuleInterop": true,
     "incremental": true,
+    "isolatedModules": true,
     "jsx": "react",
     "lib": ["dom", "es2015", "es2016", "DOM.Iterable"],
     "module": "esnext",
@@ -18,7 +19,6 @@
       "#layouts/*": ["src/layouts/*"],
       "#mocks/*": ["tests/mocks/*"],
       "#test_helpers/*": ["tests/helpers/*"],
-      "#types/*": ["types/*"],
       "#api": ["src/api.ts"],
       "#api_endpoints": ["src/api_endpoints.ts"],
       "#server_routes.mock": ["src/server_routes.mock.ts"]
@@ -30,5 +30,5 @@
     "strict": true,
     "target": "esnext"
   },
-  "include": ["src/**/*", "types/**/*", "tests/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "esModuleInterop": true,
+    "incremental": true,
     "jsx": "react",
     "lib": ["dom", "es2015", "es2016", "DOM.Iterable"],
     "module": "esnext",


### PR DESCRIPTION
The signature of all API functions has changed

- OLD:
  - Return a promise, resolving with the Axios response object or rejecting with the Axios error object

- NEW:
  - Accept an object providing `onSuccess` and `onError` handlers.
    - `onSuccess()` is called with the requested data directly, not the Axios object *containing* the data
    - `onError()` is called with 2 parameters: An error message to use in the UI and the Axios error object
  - Return an object with a function `cancel` and a promise `completed`
    - If `cancel()` is called before the request has been completed, neither `onSuccess` nor `onError` will be called
    - `completed` resolves (to `undefined`) when the request is completed, whether by success, error, or cancellation

Other notable changes:

* We now handle request logic in `baseRequest()`, which is called by all other API functions in the module
* Endpoints for fetching all rows of a table now include `/all` in the path (e.g. `/categories` is now `/categories/all`)
* One-off test runs take less time now due to setting `isolatedModules` in `jest.config.js` (and in `tsconfig.json`, but that's just for consistency). Watch mode test runs are unaffected.
