### PR TITLE
Update styles and layout

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,9 @@ module.exports = {
     // Let TypeScript handle validating return values
     "consistent-return": "off",
 
+    // @typescript/eslint/no-var-requires already disallows require() entirely
+    "global-require": "off",
+
     // Be explicit when an import is only used as a type
     "@typescript-eslint/consistent-type-imports": ["error"],
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,12 @@
 import { Auth0Provider } from "@auth0/auth0-react";
 import type { AppState } from "@auth0/auth0-react";
 import { Router, navigate } from "@reach/router";
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { setupWorker } from "msw"; // Dev usage only
 import React, { useState } from "react";
 import { Root, addPrefetchExcludes } from "react-static";
 import { ThemeProvider, createGlobalStyle } from "styled-components";
 
 import { BurgerButton } from "#components/BurgerButton";
 import { Nav } from "#components/Nav";
-import { handlers } from "#server_routes.mock"; // Dev usage only
 import HomePage from "./pages";
 import NotFound from "./pages/404";
 import CategoriesPage from "./pages/categories";
@@ -27,6 +24,11 @@ if (
   process.env.NODE_ENV !== "production" &&
   typeof document !== undefined
 ) {
+  // Use conditional require() instead of import to prevent bundling these files
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
+  const { setupWorker } = require("msw");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { handlers } = require("#server_routes.mock");
   setupWorker(...handlers).start();
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import type { AppState } from "@auth0/auth0-react";
 import { Router, navigate } from "@reach/router";
 import React, { useState } from "react";
 import { Root, addPrefetchExcludes } from "react-static";
-import { ThemeProvider, createGlobalStyle } from "styled-components";
+import styled, { ThemeProvider } from "styled-components";
 
 import { BurgerButton } from "#components/BurgerButton";
 import { Nav } from "#components/Nav";
@@ -32,16 +32,7 @@ if (
   setupWorker(...handlers).start();
 }
 
-const GlobalStyle = createGlobalStyle`
-  *, ::before, ::after {
-    box-sizing: border-box;
-  }
-
-  body {
-    width: 100%;
-  }
-
- header {
+const StyledHeader = styled.header`
   display: flex;
   height: ${({ theme }) => theme.headerHeight};
   background: ${({ theme }) => theme.headerBg};
@@ -57,7 +48,6 @@ const GlobalStyle = createGlobalStyle`
       display: none;
     }
   }
- }
 `;
 
 const isBrowser = typeof window !== "undefined";
@@ -84,15 +74,14 @@ export function App(): JSX.Element {
         useRefreshTokens
       >
         <ThemeProvider theme={defaultTheme}>
-          <GlobalStyle />
-          <header>
+          <StyledHeader>
             <h1>Instrument Catalog</h1>
             <BurgerButton
               className="burger"
               onClick={toggleNav}
               navIsVisible={navIsVisible}
             />
-          </header>
+          </StyledHeader>
           <Nav
             links={[
               ["Home", "/"],

--- a/src/app.css
+++ b/src/app.css
@@ -7,7 +7,9 @@ body {
 }
 
 main {
+  margin: auto;
   padding: 1rem;
+  max-width: 900px;
 }
 
 section {

--- a/src/app.css
+++ b/src/app.css
@@ -1,7 +1,6 @@
 body {
   font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue",
     Helvetica, Arial, "Lucida Grande", sans-serif;
-  font-weight: 300;
   font-size: 16px;
   margin: 0;
   padding: 0;

--- a/src/app.css
+++ b/src/app.css
@@ -41,14 +41,3 @@ img {
   max-width: 100%;
   max-height: 100%;
 }
-
-nav {
-  width: 100%;
-  background: #108db8;
-}
-
-nav a {
-  color: white;
-  padding: 1rem;
-  display: inline-block;
-}

--- a/src/app.css
+++ b/src/app.css
@@ -1,9 +1,16 @@
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
 body {
   font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue",
     Helvetica, Arial, "Lucida Grande", sans-serif;
   font-size: 16px;
   margin: 0;
   padding: 0;
+  width: 100%;
 }
 
 main {

--- a/src/components/BaseButton.tsx
+++ b/src/components/BaseButton.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const BaseButton = styled.button<{ bgColor?: string }>`
+  border: 2px solid #bbb;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-size: 1rem;
+  line-height: 1rem;
+  background: ${({ bgColor }) => bgColor ?? "#ddd"};
+`;

--- a/src/components/BurgerButton/BurgerButton.unit.test.tsx
+++ b/src/components/BurgerButton/BurgerButton.unit.test.tsx
@@ -5,6 +5,8 @@ import { BurgerButton } from "./BurgerButton";
 
 const noop = (): void => undefined;
 
+// NOTE: We're not testing className or onClick props, since they're just
+// applied directly to the component's root element.
 describe("<BurgerButton />", () => {
   describe("given navIsVisible=true", () => {
     it("renders 'close menu' interface", () => {
@@ -19,7 +21,4 @@ describe("<BurgerButton />", () => {
       expect(screen.getByLabelText(/open menu/i)).toBeInTheDocument();
     });
   });
-
-  // NOTE: We're not testing className or onClick, since they're just passed
-  // to the component's root element. We don't test implementation details.
 });

--- a/src/components/CategoryListItem/CategoryListItem.tsx
+++ b/src/components/CategoryListItem/CategoryListItem.tsx
@@ -47,7 +47,7 @@ export function CategoryListItem({
         <div title="Number of instruments in this category">{itemCount}</div>
       </HeadingContainer>
       <p>{summary}</p>
-      {description ? <p>{description}</p> : undefined}
+      {description && <p>{description}</p>}
     </section>
   );
 }

--- a/src/components/CategoryListItem/CategoryListItem.tsx
+++ b/src/components/CategoryListItem/CategoryListItem.tsx
@@ -44,7 +44,7 @@ export function CategoryListItem({
         <h3>
           <Link to={url}>{name}</Link>
         </h3>
-        <div title="Instruments in this category">{itemCount}</div>
+        <div title="Number of instruments in this category">{itemCount}</div>
       </HeadingContainer>
       <p>{summary}</p>
       {description ? <p>{description}</p> : undefined}

--- a/src/components/DeleteInstrumentButton/DeleteInstrumentButton.tsx
+++ b/src/components/DeleteInstrumentButton/DeleteInstrumentButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { BaseButton } from "#components/BaseButton";
+import type { IInstrument } from "#src/types";
+
+export type DeleteInstrumentButtonProps = Pick<IInstrument, "id" | "name">;
+
+export function DeleteInstrumentButton({
+  id,
+  name,
+}: DeleteInstrumentButtonProps): JSX.Element {
+  const handleClick = () => {
+    if (window.confirm(`Are you sure you want to delete ${name}?`)) {
+      console.log(`TODO: Delete instrument ${id} and navigate to "/"`);
+      window.alert("'Delete Instrument' Hasn't been implemented yet");
+    }
+  };
+
+  return (
+    <BaseButton bgColor="#f66" onClick={handleClick}>
+      Delete instrument
+    </BaseButton>
+  );
+}

--- a/src/components/DeleteInstrumentButton/DeleteInstrumentButton.unit.test.tsx
+++ b/src/components/DeleteInstrumentButton/DeleteInstrumentButton.unit.test.tsx
@@ -1,0 +1,41 @@
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { renderWithRouter } from "#test_helpers/renderWithRouter";
+import { DeleteInstrumentButton } from "./DeleteInstrumentButton";
+
+describe("<DeleteInstrumentButton />", () => {
+  describe("If the deletion is confirmed", () => {
+    it.skip("deletes the instrument and navigates to the home page", () => {
+      const { history, getByRole } = renderWithRouter(
+        <DeleteInstrumentButton id={0} name="Flute" />,
+        "/initial/path/"
+      );
+
+      expect(history.location.pathname).toBe("/initial/path/");
+      userEvent.click(getByRole("button"));
+
+      // TODO Click confirm
+      // TODO Verify instrument is deleted
+
+      expect(history.location.pathname).toBe("/");
+    });
+  });
+
+  describe("If the deletion is cancelled", () => {
+    it.skip("does not delete the instrument or naviage", () => {
+      const { history, getByRole } = renderWithRouter(
+        <DeleteInstrumentButton id={0} name="Flute" />,
+        "/initial/path/"
+      );
+
+      expect(history.location.pathname).toBe("/initial/path/");
+      userEvent.click(getByRole("button"));
+
+      // TODO Click cancel
+      // TODO Verify instrument is not deleted
+
+      expect(history.location.pathname).toBe("/initial/path/");
+    });
+  });
+});

--- a/src/components/DeleteInstrumentButton/index.tsx
+++ b/src/components/DeleteInstrumentButton/index.tsx
@@ -1,0 +1,2 @@
+export { DeleteInstrumentButton } from "./DeleteInstrumentButton";
+export type { DeleteInstrumentButtonProps } from "./DeleteInstrumentButton";

--- a/src/components/EditInstrumentButton/EditInstrumentButton.tsx
+++ b/src/components/EditInstrumentButton/EditInstrumentButton.tsx
@@ -1,0 +1,16 @@
+import { useNavigate } from "@reach/router";
+import React from "react";
+
+import { BaseButton } from "#components/BaseButton";
+import type { IInstrument } from "#src/types";
+import { getInstrumentPath } from "#utils/paths";
+
+export type EditInstrumentButtonProps = Pick<IInstrument, "id" | "name">;
+
+export function EditInstrumentButton(
+  idAndName: EditInstrumentButtonProps
+): JSX.Element {
+  const navigate = useNavigate();
+  const url = getInstrumentPath(idAndName, /* isEditPage */ true);
+  return <BaseButton onClick={() => navigate(url)}>Edit instrument</BaseButton>;
+}

--- a/src/components/EditInstrumentButton/EditInstrumentButton.unit.test.tsx
+++ b/src/components/EditInstrumentButton/EditInstrumentButton.unit.test.tsx
@@ -1,0 +1,18 @@
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { renderWithRouter } from "#test_helpers/renderWithRouter";
+import { EditInstrumentButton } from "./EditInstrumentButton";
+
+describe("<EditInstrumentButton />", () => {
+  it("navigates to the instrument's edit page when clicked", () => {
+    const { history, getByRole } = renderWithRouter(
+      <EditInstrumentButton id={7} name="Foo Bar" />,
+      "/initial/path/"
+    );
+
+    expect(history.location.pathname).toBe("/initial/path/");
+    userEvent.click(getByRole("button"));
+    expect(history.location.pathname).toBe("/instruments/7/Foo%20Bar/edit/");
+  });
+});

--- a/src/components/EditInstrumentButton/index.tsx
+++ b/src/components/EditInstrumentButton/index.tsx
@@ -1,0 +1,2 @@
+export { EditInstrumentButton } from "./EditInstrumentButton";
+export type { EditInstrumentButtonProps } from "./EditInstrumentButton";

--- a/src/components/InstrumentList/InstrumentList.tsx
+++ b/src/components/InstrumentList/InstrumentList.tsx
@@ -14,7 +14,7 @@ export function InstrumentList({
     <>
       {instruments.map(({ id, name, summary }, index) => (
         <Fragment key={id}>
-          {index > 0 ? <hr /> : undefined}
+          {index > 0 && <hr />}
           <InstrumentListItem id={id} name={name} summary={summary} />
         </Fragment>
       ))}

--- a/src/components/LoginButton/LoginButton.tsx
+++ b/src/components/LoginButton/LoginButton.tsx
@@ -1,17 +1,14 @@
 import React from "react";
 
+import { BaseButton } from "#components/BaseButton";
 import { useAuth } from "#hooks/useAuth";
 
 export function LoginButton(): JSX.Element {
   const auth = useAuth();
 
   return auth.state === "AUTHENTICATED" ? (
-    <button type="button" onClick={() => auth.logout()}>
-      Log out
-    </button>
+    <BaseButton onClick={() => auth.logout()}>Log out</BaseButton>
   ) : (
-    <button type="button" onClick={() => auth.login()}>
-      Log in
-    </button>
+    <BaseButton onClick={() => auth.login()}>Log in</BaseButton>
   );
 }

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -20,32 +20,51 @@ const GlobalStyle = createGlobalStyle`
 
 const StyledNav = styled.nav`
   position: absolute;
+  width: 100%;
   height: calc(100vh - ${({ theme }) => theme.headerHeight});
   overflow-y: auto;
   left: 100%;
   transition: left 0.2s ease-in-out;
+  background: #108db8;
 
   body.nav-visible & {
     left: 0;
   }
 
-  & button {
-    font-size: 0.9em;
+  button {
+    margin: 1rem;
   }
 
-  & ul {
+  ul {
     margin: 0;
     padding: 0;
     list-style: none;
+  }
+
+  a {
+    display: inline-block;
+    color: white;
+    padding: 1rem;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background: rgba(0, 0, 0, 0.1);
+    }
   }
 
   @media (min-width: ${({ theme }) => theme.mobileBreakpoint}) {
     position: static;
     display: flex;
     justify-content: space-between;
+    padding: 0;
     height: auto;
 
-    & ul {
+    button {
+      margin: 0;
+    }
+
+    ul {
       order: -1;
       display: flex;
     }

--- a/src/layouts/Categories/Categories.tsx
+++ b/src/layouts/Categories/Categories.tsx
@@ -21,7 +21,7 @@ export function Categories({
       ) : (
         categories.map((category, index) => (
           <Fragment key={category.name}>
-            {index > 0 ? <hr /> : undefined}
+            {index > 0 && <hr />}
             <CategoryListItem
               name={category.name}
               itemCount={category.itemCount}

--- a/src/layouts/Instrument/Instrument.tsx
+++ b/src/layouts/Instrument/Instrument.tsx
@@ -2,7 +2,11 @@ import type { RouteComponentProps } from "@reach/router";
 import React from "react";
 import styled from "styled-components";
 
+import { DeleteInstrumentButton } from "#components/DeleteInstrumentButton";
+import { EditInstrumentButton } from "#components/EditInstrumentButton";
+import { useAuth } from "#hooks/useAuth";
 import type { IInstrument } from "#src/types";
+import { canEditOrDelete } from "#utils/access_control";
 
 const imgMaxWidth = "400px";
 const imgMaxHeight = "600px";
@@ -18,6 +22,12 @@ const InstrumentContainer = styled.div`
     width: 50vw;
     max-width: ${imgMaxWidth};
     max-height: ${imgMaxHeight};
+  }
+
+  .button-container {
+    display: flex;
+    justify-content: space-around;
+    margin: 1em 0 0.5em;
   }
 
   h2 {
@@ -46,29 +56,51 @@ const InstrumentContainer = styled.div`
       max-width: none;
       max-height: none;
     }
+
+    .button-container {
+      flex-flow: row wrap;
+      justify-content: center;
+      margin: 0;
+
+      & > button {
+        margin: 0 0.5em 1em;
+      }
+    }
   }
 `;
 
 export type InstrumentProps = Pick<
   IInstrument,
-  "name" | "summary" | "description" | "imageUrl"
+  "id" | "userId" | "name" | "summary" | "description" | "imageUrl"
 > & {
   categoryName: string;
 };
 
 export function Instrument({
+  id,
+  userId,
   name,
   categoryName,
   summary,
   description,
   imageUrl,
 }: InstrumentProps & RouteComponentProps): JSX.Element {
+  const auth = useAuth();
+  const userCanModify =
+    auth.state === "AUTHENTICATED" && canEditOrDelete(auth.user, { userId });
+
   return (
     <InstrumentContainer>
       <h2>{name}</h2>
       <div className="img-container">
         <img src={imageUrl} alt={name} />
       </div>
+      {userCanModify && (
+        <div className="button-container">
+          <EditInstrumentButton id={id} name={name} />
+          <DeleteInstrumentButton id={id} name={name} />
+        </div>
+      )}
       <p>{summary}</p>
       <p>
         <strong>Category:</strong> {categoryName}

--- a/src/layouts/Instrument/Instrument.tsx
+++ b/src/layouts/Instrument/Instrument.tsx
@@ -52,10 +52,13 @@ const InstrumentContainer = styled.div`
 export type InstrumentProps = Pick<
   IInstrument,
   "name" | "summary" | "description" | "imageUrl"
->;
+> & {
+  categoryName: string;
+};
 
 export function Instrument({
   name,
+  categoryName,
   summary,
   description,
   imageUrl,
@@ -67,6 +70,9 @@ export function Instrument({
         <img src={imageUrl} alt={name} />
       </div>
       <p>{summary}</p>
+      <p>
+        <strong>Category:</strong> {categoryName}
+      </p>
       <hr />
       <p>{description}</p>
     </InstrumentContainer>

--- a/src/layouts/Instrument/Instrument.unit.test.tsx
+++ b/src/layouts/Instrument/Instrument.unit.test.tsx
@@ -1,13 +1,21 @@
-import { render, screen } from "@testing-library/react";
 import React from "react";
 
+import {
+  mockAuthenticatedUser,
+  useAuth,
+  UNAUTHENTICATED,
+} from "#mocks/useAuth";
+import { renderWithRouter } from "#test_helpers/renderWithRouter";
 import { Instrument } from "./Instrument";
 
 describe("<Instrument />", () => {
-  describe("given required props", () => {
-    it("renders the provided props", () => {
-      render(
+  describe("when logged out", () => {
+    it("renders provided values, does not render Edit/Delete buttons", () => {
+      useAuth.mockReturnValue(UNAUTHENTICATED);
+      const { getByRole, getByText, queryByRole } = renderWithRouter(
         <Instrument
+          id={3}
+          userId="foo|123"
           name="Foo"
           categoryName="Bar category"
           summary="My Foo summary"
@@ -16,16 +24,68 @@ describe("<Instrument />", () => {
         />
       );
 
-      const img = screen.getByRole("img");
+      const img = getByRole("img");
       expect(img).toHaveAttribute("src", "http://foo.com/");
       expect(img).toHaveAttribute("alt", "Foo");
 
-      const heading2 = screen.getByRole("heading", { level: 2 });
-      expect(heading2).toHaveTextContent("Foo");
+      expect(getByRole("heading", { level: 2 })).toHaveTextContent("Foo");
 
-      expect(screen.getByText(/bar category/i)).toBeInTheDocument();
-      expect(screen.getByText("My Foo summary")).toBeInTheDocument();
-      expect(screen.getByText("My description of Foo")).toBeInTheDocument();
+      expect(getByText(/bar category/i)).toBeInTheDocument();
+      expect(getByText("My Foo summary")).toBeInTheDocument();
+      expect(getByText("My description of Foo")).toBeInTheDocument();
+
+      const editBtn = queryByRole("button", { name: /edit instrument/i });
+      expect(editBtn).not.toBeInTheDocument();
+
+      const deleteBtn = queryByRole("button", { name: /delete instrument/i });
+      expect(deleteBtn).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when logged in", () => {
+    it.each([
+      ["the instrument owner", () => mockAuthenticatedUser("owner")],
+      ["an admin", () => mockAuthenticatedUser("notOwner", /* isAdmin */ true)],
+    ])("renders Edit and Delete buttons for %s", (_, mockAuthState) => {
+      mockAuthState();
+      const { getByRole } = renderWithRouter(
+        <Instrument
+          id={3}
+          userId="owner"
+          name="Foo"
+          categoryName="Bar category"
+          summary="My Foo summary"
+          description="My description of Foo"
+          imageUrl="http://foo.com/"
+        />
+      );
+
+      const editBtn = getByRole("button", { name: /edit instrument/i });
+      expect(editBtn).toBeInTheDocument();
+
+      const deleteBtn = getByRole("button", { name: /delete instrument/i });
+      expect(deleteBtn).toBeInTheDocument();
+    });
+
+    it("does not render Edit or Delete buttons for non-owners", () => {
+      mockAuthenticatedUser("notOwner");
+      const { queryByRole } = renderWithRouter(
+        <Instrument
+          id={3}
+          userId="owner"
+          name="Foo"
+          categoryName="Bar category"
+          summary="My Foo summary"
+          description="My description of Foo"
+          imageUrl="http://foo.com/"
+        />
+      );
+
+      const editBtn = queryByRole("button", { name: /edit instrument/i });
+      expect(editBtn).not.toBeInTheDocument();
+
+      const deleteBtn = queryByRole("button", { name: /delete instrument/i });
+      expect(deleteBtn).not.toBeInTheDocument();
     });
   });
 });

--- a/src/layouts/Instrument/Instrument.unit.test.tsx
+++ b/src/layouts/Instrument/Instrument.unit.test.tsx
@@ -9,6 +9,7 @@ describe("<Instrument />", () => {
       render(
         <Instrument
           name="Foo"
+          categoryName="Bar category"
           summary="My Foo summary"
           description="My description of Foo"
           imageUrl="http://foo.com/"
@@ -22,6 +23,7 @@ describe("<Instrument />", () => {
       const heading2 = screen.getByRole("heading", { level: 2 });
       expect(heading2).toHaveTextContent("Foo");
 
+      expect(screen.getByText(/bar category/i)).toBeInTheDocument();
       expect(screen.getByText("My Foo summary")).toBeInTheDocument();
       expect(screen.getByText("My description of Foo")).toBeInTheDocument();
     });

--- a/src/pages/instrument.tsx
+++ b/src/pages/instrument.tsx
@@ -142,6 +142,8 @@ export default function InstrumentPage(_: RouteComponentProps): JSX.Element {
     <Suspense fallback={<p>{loadingMessage}</p>}>
       <Instrument
         path="/"
+        id={instrument.id}
+        userId={instrument.userId}
         name={instrument.name}
         categoryName={categoryName}
         summary={instrument.summary}

--- a/src/pages/instrument.tsx
+++ b/src/pages/instrument.tsx
@@ -5,6 +5,7 @@ import React, { Suspense, useEffect, useState } from "react";
 import { getInstrumentById } from "#api";
 import { LoginButton } from "#components/LoginButton";
 import { useAuth } from "#hooks/useAuth";
+import { useCategories } from "#hooks/useCategories";
 import NotFound from "#src/pages/404";
 import type { IInstrument } from "#src/types";
 import { canEditOrDelete } from "#utils/access_control";
@@ -37,6 +38,7 @@ export default function InstrumentPage(_: RouteComponentProps): JSX.Element {
   const [instrument, setInstrument] = useState<IInstrument | undefined>();
   const [instrumentExists, setInstrumentExists] = useState(true);
   const auth = useAuth();
+  const { categories, categoriesHaveLoaded } = useCategories();
   const location = useLocation();
   const navigate = useNavigate();
   const isEditPage = /\/edit\/?$/.test(location.pathname);
@@ -131,11 +133,17 @@ export default function InstrumentPage(_: RouteComponentProps): JSX.Element {
     }
   }
 
+  const category = categories.find(({ id }) => id === instrument.categoryId);
+  const categoryName = categoriesHaveLoaded
+    ? category?.name || "Not defined"
+    : "";
+
   return (
     <Suspense fallback={<p>{loadingMessage}</p>}>
       <Instrument
         path="/"
         name={instrument.name}
+        categoryName={categoryName}
         summary={instrument.summary}
         description={instrument.description}
         imageUrl={instrument.imageUrl}

--- a/src/server_routes.mock.ts
+++ b/src/server_routes.mock.ts
@@ -31,6 +31,7 @@ export const MOCK_DATA: {
       id: 0,
       name: "Winds",
       slug: "winds",
+      // itemCount is hard coded to see how different numbers of digits render
       itemCount: 3,
       summary: "Move air, make noise",
       description: "This is a longer description of wind instruments.",

--- a/static.config.js
+++ b/static.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import "dotenv/config"; // Load environment variables from .env
+import React from "react";
 
 // Typescript support in static.config.js is not yet supported, but is coming in a future update!
 
@@ -47,6 +48,17 @@ import "dotenv/config"; // Load environment variables from .env
 })();
 
 export default {
+  // eslint-disable-next-line react/prop-types
+  Document: ({ Html, Head, Body, children }) => (
+    <Html lang="en-US">
+      <Head>
+        <meta charSet="utf-8" />
+        <title>Instrument Catalog</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Body>{children}</Body>
+    </Html>
+  ),
   entry: "index.tsx", // Relative to paths.src
   plugins: [
     ["react-static-plugin-typescript", { typeCheck: false }], // Lint separately


### PR DESCRIPTION
Notable changes:

- Add `<EditInstrumentButton />` and `<DeleteInstrumentButton />` (the latter is just a placeholder for now, since we haven't implemented the API call for it yet)
- Show the category name on instrument view pages
- Define a base HTML document, making sure a `<title>` is set
- Limit width of `<main>` so content doesn't sprawl
- Improve styles for `<nav>`, especially on mobile

A little out of place for this PR, but also:

- Prevent bundling a dev dependency (`msw`) and a dev-only module (`src/server_routes.mock.ts`) in production builds
