### PR TITLE
Add <ModalConfirm /> for confirmation prompts

### DIFF
--- a/src/components/BaseButton.tsx
+++ b/src/components/BaseButton.tsx
@@ -1,7 +1,13 @@
 import styled from "styled-components";
 
-export const BaseButton = styled.button<{ bgColor?: string }>`
-  border: 2px solid #bbb;
+export interface BaseButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  bgColor?: string;
+  // eslint requires "type" for raw <button>s, so let's do the same here
+  type: NonNullable<React.ButtonHTMLAttributes<HTMLButtonElement>["type"]>;
+}
+
+export const BaseButton = styled.button<BaseButtonProps>`
   border-radius: 0.5rem;
   padding: 0.75rem;
   font-size: 1rem;

--- a/src/components/DeleteInstrumentButton/DeleteInstrumentButton.tsx
+++ b/src/components/DeleteInstrumentButton/DeleteInstrumentButton.tsx
@@ -1,7 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { BaseButton } from "#components/BaseButton";
+import { ModalConfirm } from "#components/ModalConfirm";
 import type { IInstrument } from "#src/types";
+
+const noop = (): void => undefined;
+const baseModalState = {
+  showModal: false,
+  question: "",
+  handleYes: noop,
+  // handleNo is defined in the useState initial value
+};
 
 export type DeleteInstrumentButtonProps = Pick<IInstrument, "id" | "name">;
 
@@ -9,16 +18,41 @@ export function DeleteInstrumentButton({
   id,
   name,
 }: DeleteInstrumentButtonProps): JSX.Element {
+  const [modalState, setModalState] = useState({
+    ...baseModalState,
+    handleNo: () =>
+      setModalState({ ...baseModalState, handleNo: modalState.handleNo }),
+  });
+  const hideModal = modalState.handleNo;
+
   const handleClick = () => {
-    if (window.confirm(`Are you sure you want to delete ${name}?`)) {
-      console.log(`TODO: Delete instrument ${id} and navigate to "/"`);
-      window.alert("'Delete Instrument' Hasn't been implemented yet");
-    }
+    setModalState({
+      ...modalState,
+      showModal: true,
+      question: `Are you sure you want to PERMANENTLY DELETE “${name}”?`,
+      handleYes: () => {
+        console.log(`TODO: Delete instrument ${id} and navigate to "/"`);
+        window.alert("'Delete Instrument' has not been implemented yet");
+        hideModal();
+      },
+    });
   };
 
   return (
-    <BaseButton bgColor="#f66" onClick={handleClick}>
-      Delete instrument
-    </BaseButton>
+    <>
+      {modalState.showModal && (
+        <ModalConfirm
+          yesText="Yes, delete it"
+          noText="No, keep it"
+          onYes={modalState.handleYes}
+          onNo={modalState.handleNo}
+        >
+          {modalState.question}
+        </ModalConfirm>
+      )}
+      <BaseButton type="button" bgColor="#f66" onClick={handleClick}>
+        Delete instrument
+      </BaseButton>
+    </>
   );
 }

--- a/src/components/DeleteInstrumentButton/DeleteInstrumentButton.unit.test.tsx
+++ b/src/components/DeleteInstrumentButton/DeleteInstrumentButton.unit.test.tsx
@@ -7,15 +7,19 @@ import { DeleteInstrumentButton } from "./DeleteInstrumentButton";
 describe("<DeleteInstrumentButton />", () => {
   describe("If the deletion is confirmed", () => {
     it.skip("deletes the instrument and navigates to the home page", () => {
-      const { history, getByRole } = renderWithRouter(
+      const { history, getByRole, getByText, queryByText } = renderWithRouter(
         <DeleteInstrumentButton id={0} name="Flute" />,
         "/initial/path/"
       );
 
       expect(history.location.pathname).toBe("/initial/path/");
-      userEvent.click(getByRole("button"));
+      expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
+      userEvent.click(getByRole("button", { name: /delete instrument/i }));
+      expect(getByText(/are you sure/i)).toBeInTheDocument();
 
-      // TODO Click confirm
+      userEvent.click(getByRole("button", { name: /yes/i }));
+      expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
+
       // TODO Verify instrument is deleted
 
       expect(history.location.pathname).toBe("/");
@@ -24,15 +28,19 @@ describe("<DeleteInstrumentButton />", () => {
 
   describe("If the deletion is cancelled", () => {
     it.skip("does not delete the instrument or naviage", () => {
-      const { history, getByRole } = renderWithRouter(
+      const { history, getByRole, getByText, queryByText } = renderWithRouter(
         <DeleteInstrumentButton id={0} name="Flute" />,
         "/initial/path/"
       );
 
       expect(history.location.pathname).toBe("/initial/path/");
-      userEvent.click(getByRole("button"));
+      expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
+      userEvent.click(getByRole("button", { name: /delete instrument/i }));
+      expect(getByText(/are you sure/i)).toBeInTheDocument();
 
-      // TODO Click cancel
+      userEvent.click(getByRole("button", { name: /no/i }));
+      expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
+
       // TODO Verify instrument is not deleted
 
       expect(history.location.pathname).toBe("/initial/path/");

--- a/src/components/EditInstrumentButton/EditInstrumentButton.tsx
+++ b/src/components/EditInstrumentButton/EditInstrumentButton.tsx
@@ -12,5 +12,9 @@ export function EditInstrumentButton(
 ): JSX.Element {
   const navigate = useNavigate();
   const url = getInstrumentPath(idAndName, /* isEditPage */ true);
-  return <BaseButton onClick={() => navigate(url)}>Edit instrument</BaseButton>;
+  return (
+    <BaseButton type="button" onClick={() => navigate(url)}>
+      Edit instrument
+    </BaseButton>
+  );
 }

--- a/src/components/LoginButton/LoginButton.tsx
+++ b/src/components/LoginButton/LoginButton.tsx
@@ -7,8 +7,12 @@ export function LoginButton(): JSX.Element {
   const auth = useAuth();
 
   return auth.state === "AUTHENTICATED" ? (
-    <BaseButton onClick={() => auth.logout()}>Log out</BaseButton>
+    <BaseButton type="button" onClick={() => auth.logout()}>
+      Log out
+    </BaseButton>
   ) : (
-    <BaseButton onClick={() => auth.login()}>Log in</BaseButton>
+    <BaseButton type="button" onClick={() => auth.login()}>
+      Log in
+    </BaseButton>
   );
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -23,7 +23,9 @@ const StyledModal = styled.div`
   align-items: center;
 
   > div {
+    border 2px solid #aaa;
     padding: 1em;
+    max-width: 18em;
     background: white;
   }
 `;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styled, { createGlobalStyle } from "styled-components";
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    overflow: hidden;
+  }
+`;
+
+// <dialog> might be better than <div>, once it has wider support
+const StyledModal = styled.div`
+  // Cover the whole page
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+
+  // Center the child div
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  > div {
+    padding: 1em;
+    background: white;
+  }
+`;
+
+export interface ModalProps {
+  children: React.ReactNode | React.ReactNode[];
+}
+
+/** This modal is static, so parent components must render it conditionally */
+export function Modal({ children }: ModalProps): JSX.Element {
+  return (
+    <StyledModal>
+      <GlobalStyle />
+      <div>{children}</div>
+    </StyledModal>
+  );
+}

--- a/src/components/Modal/Modal.unit.test.tsx
+++ b/src/components/Modal/Modal.unit.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import React from "react";
+
+import { Modal } from "./Modal";
+
+describe("<Modal />", () => {
+  it("renders children", () => {
+    const { getByTestId } = render(
+      <Modal>
+        <div data-testid="foo" />
+        <div data-testid="bar" />
+      </Modal>
+    );
+    expect(getByTestId("foo")).toBeInTheDocument();
+    expect(getByTestId("bar")).toBeInTheDocument();
+  });
+});

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,1 @@
+export { Modal } from "./Modal";

--- a/src/components/ModalConfirm/ModalConfirm.tsx
+++ b/src/components/ModalConfirm/ModalConfirm.tsx
@@ -13,7 +13,7 @@ const ConfirmContainer = styled.div`
 
   div {
     display: flex;
-    justify-content: space-between;
+    justify-content: space-around;
 
     button:first-child {
       margin-right: 1rem;

--- a/src/components/ModalConfirm/ModalConfirm.tsx
+++ b/src/components/ModalConfirm/ModalConfirm.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import styled from "styled-components";
+
+import { BaseButton } from "#components/BaseButton";
+import { Modal } from "#components/Modal";
+
+const ConfirmContainer = styled.div`
+  p {
+    margin: 0 0 1rem;
+    text-align: center;
+    font-weight: bold;
+  }
+
+  div {
+    display: flex;
+    justify-content: space-between;
+
+    button:first-child {
+      margin-right: 1rem;
+    }
+  }
+`;
+
+export interface ModalConfirmProps {
+  /** `children` should be the question being asked of the user */
+  children: string | string[];
+  onYes: () => unknown;
+  onNo: () => unknown;
+  yesText?: string;
+  noText?: string;
+}
+
+export function ModalConfirm({
+  children,
+  onYes,
+  onNo,
+  yesText = "Yes",
+  noText = "No",
+}: ModalConfirmProps): JSX.Element {
+  return (
+    <Modal>
+      <ConfirmContainer>
+        <p>{children}</p>
+        <div>
+          <BaseButton type="button" onClick={onYes}>
+            {yesText}
+          </BaseButton>
+          <BaseButton type="button" onClick={onNo}>
+            {noText}
+          </BaseButton>
+        </div>
+      </ConfirmContainer>
+    </Modal>
+  );
+}

--- a/src/components/ModalConfirm/ModalConfirm.unit.test.tsx
+++ b/src/components/ModalConfirm/ModalConfirm.unit.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { ModalConfirm } from "./ModalConfirm";
+
+describe("<ModalConfirm />", () => {
+  it("renders children and attaches event handlers", () => {
+    const handleYes = jest.fn();
+    const handleNo = jest.fn();
+    const { getByRole, getByText } = render(
+      <ModalConfirm onYes={handleYes} onNo={handleNo}>
+        Are you sure?
+      </ModalConfirm>
+    );
+
+    expect(getByText("Are you sure?")).toBeInTheDocument();
+    expect(handleYes).not.toBeCalled();
+    expect(handleNo).not.toBeCalled();
+
+    userEvent.click(getByRole("button", { name: /yes/i }));
+    expect(handleYes).toBeCalled();
+    expect(handleNo).not.toBeCalled();
+
+    userEvent.click(getByRole("button", { name: /no/i }));
+    expect(handleNo).toBeCalled();
+  });
+
+  it("allows setting custom button text", () => {
+    const handleYes = jest.fn();
+    const handleNo = jest.fn();
+    const { getByRole } = render(
+      <ModalConfirm
+        yesText="Definitely!"
+        noText="Absolutely Not!"
+        onYes={handleYes}
+        onNo={handleNo}
+      >
+        Are you sure?
+      </ModalConfirm>
+    );
+
+    userEvent.click(getByRole("button", { name: "Definitely!" }));
+    expect(handleYes).toBeCalled();
+
+    userEvent.click(getByRole("button", { name: "Absolutely Not!" }));
+    expect(handleNo).toBeCalled();
+  });
+});

--- a/src/components/ModalConfirm/index.tsx
+++ b/src/components/ModalConfirm/index.tsx
@@ -1,0 +1,1 @@
+export { ModalConfirm } from "./ModalConfirm";


### PR DESCRIPTION
- Create new components: `<Modal />` (base) and `<ModalConfirm />` (with yes/no buttons)
- Prompt with `<ModalConfirm />` before resetting `<InstrumentForm />` and before deleting an instrument in `<DeleteInstrumentButton />`
