### PR TITLE
Implement functionality for <DeleteInstrumentButton />

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -203,3 +203,14 @@ export function updateInstrument(
     data: newData,
   });
 }
+
+export function deleteInstrument(
+  id: number,
+  getAccessTokenSilently: Auth0ContextInterface["getAccessTokenSilently"],
+  handlers: AuthenticatedAPIHandlers<void>
+): APIUtils {
+  return baseAuthenticatedRequest(getAccessTokenSilently, handlers, {
+    method: "DELETE",
+    url: `${ENDPOINTS.instruments}/${id}`,
+  });
+}

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -17,6 +17,8 @@ import {
 } from "#api";
 import type { APIHandlers, APIUtils, RequestParams } from "#api";
 
+type OnErrorParams = Parameters<APIHandlers<unknown>["onError"]>;
+
 const { API_ROOT } = process.env;
 
 describe("baseRequest()", () => {
@@ -428,7 +430,7 @@ describe("getCategoryBySlug()", () => {
       expect(handlers.onError).toBeCalledTimes(1);
 
       const [uiErrorMessage, error] = handlers.onError.mock
-        .calls[0] as Parameters<APIHandlers<unknown>["onError"]>;
+        .calls[0] as OnErrorParams;
       expect(uiErrorMessage).toMatch(/Error from server: "404/);
       expect(error.response?.status).toStrictEqual(404);
     });
@@ -443,9 +445,7 @@ describe("getCategoryBySlug()", () => {
       expect(handlers.onSuccess).not.toBeCalled();
       expect(handlers.onError).toBeCalledTimes(1);
 
-      const [uiErrorMessage] = handlers.onError.mock.calls[0] as Parameters<
-        APIHandlers<unknown>["onError"]
-      >;
+      const [uiErrorMessage] = handlers.onError.mock.calls[0] as OnErrorParams;
       expect(uiErrorMessage).toMatch(/Error from server/);
     });
   });
@@ -541,7 +541,7 @@ describe("getInstrumentById()", () => {
       expect(handlers.onError).toBeCalledTimes(1);
 
       const [uiErrorMessage, error] = handlers.onError.mock
-        .calls[0] as Parameters<APIHandlers<unknown>["onError"]>;
+        .calls[0] as OnErrorParams;
       expect(uiErrorMessage).toMatch(/Error from server: "404/);
       expect(error.response?.status).toStrictEqual(404);
     });

--- a/src/api.unit.test.ts
+++ b/src/api.unit.test.ts
@@ -14,6 +14,7 @@ import {
   getInstrumentById,
   createInstrument,
   updateInstrument,
+  deleteInstrument,
 } from "#api";
 import type { APIHandlers, APIUtils, RequestParams } from "#api";
 
@@ -775,6 +776,115 @@ describe("getInstrumentById()", () => {
         const { completed } = updateInstrument(
           id,
           updatedInstrumentBase,
+          getAccessTokenSilently,
+          handlers
+        );
+        await completed;
+
+        expect(handlers.onSuccess).not.toBeCalled();
+        expect(handlers.onError).toBeCalled();
+      });
+    });
+  });
+
+  describe("deleteInstrument()", () => {
+    describe("given an authenticated user", () => {
+      it.each([
+        ["the owning user", ownerAccessTokenPromise],
+        ["an admin user", adminAccessTokenPromise],
+      ])("calls onSuccess() for %s", async (_user, accessTokenPromise) => {
+        const getAccessTokenSilently = () => accessTokenPromise;
+
+        {
+          const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+          const { completed } = deleteInstrument(
+            testInstrument.id,
+            getAccessTokenSilently,
+            handlers
+          );
+          await completed;
+
+          expect(handlers.onSuccess).toBeCalled(); // No content
+          expect(handlers.onError).not.toBeCalled();
+        }
+
+        // Verify that the change persists (really a test for the mock server)
+        {
+          const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+          const { completed } = getInstrumentById(testInstrument.id, handlers);
+          await completed;
+          expect(handlers.onError).toBeCalled();
+          const [, error] = handlers.onError.mock.calls[0] as OnErrorParams;
+          expect(error.response?.status).toStrictEqual(404);
+        }
+      });
+
+      it("calls onSuccess() for a non-existant instrument ID", async () => {
+        const getAccessTokenSilently = () => nonOwnerAccessTokenPromise;
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { completed } = deleteInstrument(
+          3333, // Valid ID, but not in our mock DB
+          getAccessTokenSilently,
+          handlers
+        );
+        await completed;
+
+        expect(handlers.onSuccess).toBeCalled(); // Idempotent request
+        expect(handlers.onError).not.toBeCalled();
+      });
+
+      it("calls onError() for a user who isn't the owner", async () => {
+        const getAccessTokenSilently = () => nonOwnerAccessTokenPromise;
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { completed } = deleteInstrument(
+          testInstrument.id,
+          getAccessTokenSilently,
+          handlers
+        );
+        await completed;
+
+        expect(handlers.onSuccess).not.toBeCalled();
+        expect(handlers.onError).toBeCalled();
+      });
+    });
+
+    describe("given an invalid access token", () => {
+      const invalidJSONWebSignature = "not-a-valid-jws";
+      const jwsWithoutPayloadSub = jws.sign({
+        header: { alg: "HS256", typ: "JWT" },
+        payload: {}, // No .sub (subject/userId)
+        secret: "doesn't matter for this test",
+      });
+      it.each([
+        ["invalid JSON Web Signature", invalidJSONWebSignature],
+        ["JSON Web Signature without payload.sub", jwsWithoutPayloadSub],
+      ])("calls onError() for %s", async (_description, accessToken) => {
+        const getAccessTokenSilently = () => Promise.resolve(accessToken);
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { completed } = deleteInstrument(
+          testInstrument.id,
+          getAccessTokenSilently,
+          handlers
+        );
+        await completed;
+
+        expect(handlers.onSuccess).not.toBeCalled();
+        expect(handlers.onError).toBeCalled();
+      });
+    });
+
+    describe("given an invalid instrument ID", () => {
+      it.each([
+        ["a large integer represented in scientific notation", 1e99],
+        ["a fractional number", 1.1],
+        ["a negative integer", -1],
+        ["Infinity", Infinity],
+        ["NaN", NaN],
+      ])("calls onError() for %s", async (_description, id) => {
+        const getAccessTokenSilently = () => nonOwnerAccessTokenPromise;
+        const handlers = { onSuccess: jest.fn(), onError: jest.fn() };
+        const { completed } = deleteInstrument(
+          id,
           getAccessTokenSilently,
           handlers
         );

--- a/src/components/DeleteInstrumentButton/DeleteInstrumentButton.unit.test.tsx
+++ b/src/components/DeleteInstrumentButton/DeleteInstrumentButton.unit.test.tsx
@@ -1,35 +1,162 @@
+import { waitFor, waitForElementToBeRemoved } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import axios from "axios";
 import React from "react";
 
+import {
+  useAuth,
+  mockAuthenticatedUser,
+  ERRORED,
+  LOADING,
+  UNAUTHENTICATED,
+} from "#mocks/useAuth";
 import { renderWithRouter } from "#test_helpers/renderWithRouter";
+import { rest, server, ENDPOINTS, MOCK_DATA } from "#test_helpers/server";
 import { DeleteInstrumentButton } from "./DeleteInstrumentButton";
 
+async function expectInstrumentToExist(instrumentId: number) {
+  const url = `${ENDPOINTS.instruments}/${instrumentId}`;
+  expect(await axios.get(url)).toHaveProperty("status", 200);
+}
+
+async function expectInstrumentNotToExist(instrumentId: number) {
+  const url = `${ENDPOINTS.instruments}/${instrumentId}`;
+  const axiosError = await axios.get(url).catch((e) => e);
+  expect(axiosError).not.toHaveProperty("status");
+  expect(axiosError).toHaveProperty(["response", "status"], 404);
+}
+
+function failApiCallOnce() {
+  server.use(
+    rest.delete(`${ENDPOINTS.instruments}/*`, (_req, res, ctx) => {
+      return res.once(ctx.status(400));
+    })
+  );
+}
+
 describe("<DeleteInstrumentButton />", () => {
-  describe("If the deletion is confirmed", () => {
-    it.skip("deletes the instrument and navigates to the home page", () => {
+  describe("when a user confirms deletion", () => {
+    it("deletes the instrument and navigates to the home page", async () => {
+      const instrument = MOCK_DATA.instruments[0];
+      mockAuthenticatedUser(instrument.userId);
       const { history, getByRole, getByText, queryByText } = renderWithRouter(
-        <DeleteInstrumentButton id={0} name="Flute" />,
+        <DeleteInstrumentButton id={instrument.id} name={instrument.name} />,
         "/initial/path/"
       );
 
       expect(history.location.pathname).toBe("/initial/path/");
       expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
       userEvent.click(getByRole("button", { name: /delete instrument/i }));
-      expect(getByText(/are you sure/i)).toBeInTheDocument();
+      const modal = getByText(/are you sure/i);
 
-      userEvent.click(getByRole("button", { name: /yes/i }));
-      expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
-
-      // TODO Verify instrument is deleted
+      const yesButton = getByRole("button", { name: /yes/i });
+      userEvent.click(yesButton);
+      expect(yesButton).toBeDisabled();
+      await waitForElementToBeRemoved(modal);
 
       expect(history.location.pathname).toBe("/");
+      await expectInstrumentNotToExist(instrument.id);
+    });
+
+    it("succeeds when the instrument has already been deleted", async () => {
+      // This behavior is dependent on the API response, but we'll document it
+      mockAuthenticatedUser("foo|123");
+      const instrumentId = 9001;
+      const { history, getByRole, getByText, queryByText } = renderWithRouter(
+        <DeleteInstrumentButton id={instrumentId} name="Foo" />,
+        "/initial/path/"
+      );
+
+      await expectInstrumentNotToExist(instrumentId);
+
+      expect(history.location.pathname).toBe("/initial/path/");
+      expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
+      userEvent.click(getByRole("button", { name: /delete instrument/i }));
+      const modal = getByText(/are you sure/i);
+
+      const yesButton = getByRole("button", { name: /yes/i });
+      userEvent.click(yesButton);
+      expect(yesButton).toBeDisabled();
+      await waitForElementToBeRemoved(modal);
+
+      expect(history.location.pathname).toBe("/");
+      await expectInstrumentNotToExist(instrumentId);
+    });
+
+    it("allows retrying if the API call fails", async () => {
+      const instrument = MOCK_DATA.instruments[0];
+      mockAuthenticatedUser(instrument.userId);
+      const { getByRole, getByText } = renderWithRouter(
+        <DeleteInstrumentButton id={instrument.id} name={instrument.name} />,
+        "/initial/path/"
+      );
+
+      userEvent.click(getByRole("button", { name: /delete instrument/i }));
+      expect(getByText(/are you sure/i)).toBeInTheDocument();
+      const yesButton = getByRole("button", { name: /yes/i });
+
+      // First attempt fails (after "are you sure?" prompt)
+      failApiCallOnce();
+      userEvent.click(yesButton);
+      expect(yesButton).toBeDisabled();
+      await waitFor(() => expect(yesButton).toBeEnabled());
+      expect(getByText(/try.*again[?]/i)).toBeInTheDocument();
+      await expectInstrumentToExist(instrument.id);
+
+      // Second attempt fails (after "try again?" prompt)
+      failApiCallOnce();
+      userEvent.click(yesButton);
+      expect(yesButton).toBeDisabled();
+      await waitFor(() => expect(yesButton).toBeEnabled());
+      expect(getByText(/try.*again[?]/i)).toBeInTheDocument();
+      await expectInstrumentToExist(instrument.id);
+
+      // Third attempt succeeds
+      userEvent.click(yesButton);
+      expect(yesButton).toBeDisabled();
+      await waitForElementToBeRemoved(yesButton);
+      await expectInstrumentNotToExist(instrument.id);
+    });
+
+    it("allows cancelling after retrying", async () => {
+      const instrument = MOCK_DATA.instruments[0];
+      mockAuthenticatedUser(instrument.userId);
+      const { getByRole, getByText } = renderWithRouter(
+        <DeleteInstrumentButton id={instrument.id} name={instrument.name} />,
+        "/initial/path/"
+      );
+
+      userEvent.click(getByRole("button", { name: /delete instrument/i }));
+      expect(getByText(/are you sure/i)).toBeInTheDocument();
+      const yesButton = getByRole("button", { name: /yes/i });
+
+      // First attempt fails (after "are you sure?" prompt)
+      failApiCallOnce();
+      userEvent.click(yesButton);
+      expect(yesButton).toBeDisabled();
+      await waitFor(() => expect(yesButton).toBeEnabled());
+      expect(getByText(/try.*again[?]/i)).toBeInTheDocument();
+
+      // Second attempt fails (after "try again?" prompt)
+      failApiCallOnce();
+      userEvent.click(yesButton);
+      expect(yesButton).toBeDisabled();
+      await waitFor(() => expect(yesButton).toBeEnabled());
+      expect(getByText(/try.*again[?]/i)).toBeInTheDocument();
+
+      // Third attempt is cancelled
+      userEvent.click(getByRole("button", { name: /no/i }));
+      expect(yesButton).not.toBeInTheDocument();
+      await expectInstrumentToExist(instrument.id);
     });
   });
 
-  describe("If the deletion is cancelled", () => {
-    it.skip("does not delete the instrument or naviage", () => {
+  describe("when a user cancels deletion", () => {
+    it("does not delete the instrument or navigate", async () => {
+      const instrument = MOCK_DATA.instruments[0];
+      mockAuthenticatedUser(instrument.userId);
       const { history, getByRole, getByText, queryByText } = renderWithRouter(
-        <DeleteInstrumentButton id={0} name="Flute" />,
+        <DeleteInstrumentButton id={instrument.id} name={instrument.name} />,
         "/initial/path/"
       );
 
@@ -41,9 +168,27 @@ describe("<DeleteInstrumentButton />", () => {
       userEvent.click(getByRole("button", { name: /no/i }));
       expect(queryByText(/are you sure/i)).not.toBeInTheDocument();
 
-      // TODO Verify instrument is not deleted
-
       expect(history.location.pathname).toBe("/initial/path/");
+      await expectInstrumentToExist(instrument.id);
+    });
+  });
+
+  describe("given a user who is not AUTHENTICATED", () => {
+    it.each([
+      ["ERRORED", ERRORED],
+      ["LOADING", LOADING],
+      ["UNAUTHENTICATED", UNAUTHENTICATED],
+    ])("throws when rendered while auth state is %s", (_, authState) => {
+      // Silence React's debugging output for this test
+      const originalErrorFn = console.error; // eslint-disable-line no-console
+      console.error = jest.fn(); // eslint-disable-line no-console
+
+      useAuth.mockReturnValue(authState);
+      expect(() => {
+        renderWithRouter(<DeleteInstrumentButton id={1} name="Foo" />);
+      }).toThrow(/should only be rendered when authenticated/i);
+
+      console.error = originalErrorFn; // eslint-disable-line no-console
     });
   });
 });

--- a/src/components/ModalConfirm/ModalConfirm.tsx
+++ b/src/components/ModalConfirm/ModalConfirm.tsx
@@ -28,6 +28,7 @@ export interface ModalConfirmProps {
   onNo: () => unknown;
   yesText?: string;
   noText?: string;
+  disableButtons?: boolean;
 }
 
 export function ModalConfirm({
@@ -36,16 +37,17 @@ export function ModalConfirm({
   onNo,
   yesText = "Yes",
   noText = "No",
+  disableButtons = false,
 }: ModalConfirmProps): JSX.Element {
   return (
     <Modal>
       <ConfirmContainer>
         <p>{children}</p>
         <div>
-          <BaseButton type="button" onClick={onYes}>
+          <BaseButton type="button" onClick={onYes} disabled={disableButtons}>
             {yesText}
           </BaseButton>
-          <BaseButton type="button" onClick={onNo}>
+          <BaseButton type="button" onClick={onNo} disabled={disableButtons}>
             {noText}
           </BaseButton>
         </div>

--- a/src/components/ModalConfirm/ModalConfirm.unit.test.tsx
+++ b/src/components/ModalConfirm/ModalConfirm.unit.test.tsx
@@ -46,4 +46,25 @@ describe("<ModalConfirm />", () => {
     userEvent.click(getByRole("button", { name: "Absolutely Not!" }));
     expect(handleNo).toBeCalled();
   });
+
+  it("allows disabling 'yes' and 'no' buttons", () => {
+    const handleYes = jest.fn();
+    const handleNo = jest.fn();
+    const { getByRole } = render(
+      <ModalConfirm onYes={handleYes} onNo={handleNo} disableButtons>
+        Are you sure?
+      </ModalConfirm>
+    );
+    const yesButton = getByRole("button", { name: /yes/i });
+    const noButton = getByRole("button", { name: /no/i });
+
+    expect(yesButton).toBeDisabled();
+    expect(noButton).toBeDisabled();
+
+    userEvent.click(yesButton);
+    expect(handleYes).not.toBeCalled();
+
+    userEvent.click(noButton);
+    expect(handleNo).not.toBeCalled();
+  });
 });


### PR DESCRIPTION
This PR also gives `<ModalConfirm />` a `disableButtons` prop, which can be used to avoid accidental double submissions or calling cancel after already calling confirm.
