### PR TITLE
Add "New Instrument" link to <Nav />

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,14 +83,7 @@ export function App(): JSX.Element {
               navIsVisible={navIsVisible}
             />
           </StyledHeader>
-          <Nav
-            links={[
-              ["Home", "/"],
-              ["Categories", "/categories/"],
-            ]}
-            onLinkClick={hideNav}
-            visible={navIsVisible}
-          />
+          <Nav onLinkClick={hideNav} visible={navIsVisible} />
           <main>
             <Router>
               <HomePage path="/" />

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import styled, { createGlobalStyle } from "styled-components";
 
 import { LoginButton } from "#components/LoginButton";
+import { useAuth } from "#hooks/useAuth";
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -72,12 +73,22 @@ const StyledNav = styled.nav`
 `;
 
 export interface NavProps {
-  links: [linkText: string, url: string][];
   onLinkClick: () => void;
   visible: boolean;
 }
 
-export function Nav({ links, onLinkClick, visible }: NavProps): JSX.Element {
+export function Nav({ onLinkClick, visible }: NavProps): JSX.Element {
+  const auth = useAuth();
+  const isAuthenticated = auth.state === "AUTHENTICATED";
+
+  const links: Array<{ text: string; path: string }> = [
+    { text: "Home", path: "/" },
+    ...(isAuthenticated
+      ? [{ text: "Post New Instrument", path: "/instruments/new/" }]
+      : []),
+    { text: "Categories", path: "/categories/" },
+  ];
+
   useEffect(() => {
     const navVisibleClass = "nav-visible";
     const { classList } = document.body;
@@ -94,10 +105,10 @@ export function Nav({ links, onLinkClick, visible }: NavProps): JSX.Element {
       <GlobalStyle />
       <LoginButton />
       <ul>
-        {links.map(([linkText, url]) => (
-          <li key={linkText}>
-            <Link to={url} onClick={onLinkClick}>
-              {linkText}
+        {links.map(({ text, path }) => (
+          <li key={text}>
+            <Link to={path} onClick={onLinkClick}>
+              {text}
             </Link>
           </li>
         ))}

--- a/src/components/Nav/Nav.unit.test.tsx
+++ b/src/components/Nav/Nav.unit.test.tsx
@@ -2,32 +2,60 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
+import {
+  useAuth,
+  mockAuthenticatedUser,
+  LOADING,
+  ERRORED,
+  UNAUTHENTICATED,
+} from "#mocks/useAuth";
 import { renderWithDefaultTheme } from "#test_helpers/renderWithDefaultTheme";
 import { Nav } from "./Nav";
-import type { NavProps } from "./Nav";
 
 const noop = (): void => undefined;
 
 describe("<Nav />", () => {
-  describe("given a list of text and URLs", () => {
-    it("renders a link for each text/URL pair", () => {
-      const inputLinks: NavProps["links"] = [
-        ["foo", "/foo"],
-        ["bar", "/bar"],
-      ];
-      renderWithDefaultTheme(
-        <Nav visible onLinkClick={noop} links={inputLinks} />
+  describe("given a user who is logged in", () => {
+    it("renders all links, including those requiring authentication", () => {
+      mockAuthenticatedUser("foo|123");
+      const { getByRole } = renderWithDefaultTheme(
+        <Nav visible onLinkClick={noop} />
       );
-      const links = screen.getAllByRole("link");
 
-      expect(links).toHaveLength(inputLinks.length);
+      const homeLink = getByRole("link", { name: /home/i });
+      const categoriesLink = getByRole("link", { name: /categories/i });
+      const newInstrumentLink = getByRole("link", { name: /new instrument/i });
 
-      links.forEach((link, index) => {
-        const [linkText, url] = inputLinks[index];
-        expect(link).toHaveTextContent(linkText);
-        expect(link).toHaveAttribute("href", url);
-      });
+      expect(homeLink).toHaveAttribute("href", "/");
+      expect(categoriesLink).toHaveAttribute("href", "/categories/");
+      expect(newInstrumentLink).toHaveAttribute("href", "/instruments/new/");
     });
+  });
+
+  describe("given a user who is not logged in", () => {
+    it.each([
+      ["LOADING", LOADING],
+      ["ERRORED", ERRORED],
+      ["UNAUTHENTICATED", UNAUTHENTICATED],
+    ])(
+      "omits links for pages requiring authentication when auth state is %s",
+      (_, AUTH_VALUE) => {
+        useAuth.mockReturnValue(AUTH_VALUE);
+        const { getByRole, queryByRole } = renderWithDefaultTheme(
+          <Nav visible onLinkClick={noop} />
+        );
+
+        const homeLink = getByRole("link", { name: /home/i });
+        const categoriesLink = getByRole("link", { name: /categories/i });
+        const newInstrumentLink = queryByRole("link", {
+          name: /new instrument/i,
+        });
+
+        expect(homeLink).toHaveAttribute("href", "/");
+        expect(categoriesLink).toHaveAttribute("href", "/categories/");
+        expect(newInstrumentLink).not.toBeInTheDocument();
+      }
+    );
   });
 
   // I'd rather test the `visible` property by the element's visibility instead
@@ -35,7 +63,7 @@ describe("<Nav />", () => {
   // https://github.com/jsdom/jsdom/blob/9b15aee0074870bf18ef3374d5bded9911066125/lib/jsdom/level2/style.js#L18
   describe("given a particular value for visible=...", () => {
     it("is visible when visible=true", () => {
-      renderWithDefaultTheme(<Nav visible onLinkClick={noop} links={[]} />);
+      renderWithDefaultTheme(<Nav visible onLinkClick={noop} />);
       expect(document.body).toHaveClass("nav-visible");
 
       // This would be better
@@ -43,9 +71,7 @@ describe("<Nav />", () => {
     });
 
     it("is hidden when visible=false", () => {
-      renderWithDefaultTheme(
-        <Nav visible={false} onLinkClick={noop} links={[]} />
-      );
+      renderWithDefaultTheme(<Nav visible={false} onLinkClick={noop} />);
       expect(document.body).not.toHaveClass("nav-visible");
 
       // This would be better
@@ -57,18 +83,14 @@ describe("<Nav />", () => {
   describe("given an onLinkClick handler", () => {
     it("calls the click handler for clicks on links", () => {
       const handler = jest.fn();
-      renderWithDefaultTheme(
-        <Nav visible onLinkClick={handler} links={[["foo", "#"]]} />
-      );
-      userEvent.click(screen.getByRole("link"));
+      renderWithDefaultTheme(<Nav visible onLinkClick={handler} />);
+      userEvent.click(screen.getAllByRole("link")[0]);
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
     it("does NOT call the click handler for clicks outside of links", () => {
       const handler = jest.fn();
-      renderWithDefaultTheme(
-        <Nav visible onLinkClick={handler} links={[["foo", "#"]]} />
-      );
+      renderWithDefaultTheme(<Nav visible onLinkClick={handler} />);
       userEvent.click(screen.getByRole("navigation"));
       userEvent.click(screen.getByRole("list"));
       expect(handler).not.toHaveBeenCalled();

--- a/src/components/Nav/Nav.unit.test.tsx
+++ b/src/components/Nav/Nav.unit.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -63,36 +62,49 @@ describe("<Nav />", () => {
   // https://github.com/jsdom/jsdom/blob/9b15aee0074870bf18ef3374d5bded9911066125/lib/jsdom/level2/style.js#L18
   describe("given a particular value for visible=...", () => {
     it("is visible when visible=true", () => {
+      mockAuthenticatedUser("foo|123");
       renderWithDefaultTheme(<Nav visible onLinkClick={noop} />);
       expect(document.body).toHaveClass("nav-visible");
 
       // This would be better
-      // expect(screen.getByRole("navigation")).toBeVisible();
+      // expect(getByRole("navigation")).toBeVisible();
     });
 
     it("is hidden when visible=false", () => {
+      mockAuthenticatedUser("foo|123");
       renderWithDefaultTheme(<Nav visible={false} onLinkClick={noop} />);
       expect(document.body).not.toHaveClass("nav-visible");
 
       // This would be better
       // window.innerWidth = 300
-      // expect(screen.getByRole("navigation")).not.toBeVisible();
+      // expect(getByRole("navigation")).not.toBeVisible();
     });
   });
 
   describe("given an onLinkClick handler", () => {
     it("calls the click handler for clicks on links", () => {
+      mockAuthenticatedUser("foo|123");
       const handler = jest.fn();
-      renderWithDefaultTheme(<Nav visible onLinkClick={handler} />);
-      userEvent.click(screen.getAllByRole("link")[0]);
-      expect(handler).toHaveBeenCalledTimes(1);
+      const { getAllByRole } = renderWithDefaultTheme(
+        <Nav visible onLinkClick={handler} />
+      );
+
+      const links = getAllByRole("link");
+      expect(links.length).toBeGreaterThan(0);
+
+      links.forEach((link) => userEvent.click(link));
+      expect(handler).toHaveBeenCalledTimes(links.length);
     });
 
     it("does NOT call the click handler for clicks outside of links", () => {
+      mockAuthenticatedUser("foo|123");
       const handler = jest.fn();
-      renderWithDefaultTheme(<Nav visible onLinkClick={handler} />);
-      userEvent.click(screen.getByRole("navigation"));
-      userEvent.click(screen.getByRole("list"));
+      const { getByRole } = renderWithDefaultTheme(
+        <Nav visible onLinkClick={handler} />
+      );
+
+      userEvent.click(getByRole("navigation"));
+      userEvent.click(getByRole("list"));
       expect(handler).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
The "New Instrument" link is only rendered when the user is logged in.

As part of this change, link text and paths are now defined directly in the `<Nav />` component rather than passed in as a prop.
