### PR TITLE
Update home page content

### DIFF
--- a/src/hooks/useCategories/useCategories.ts
+++ b/src/hooks/useCategories/useCategories.ts
@@ -67,13 +67,19 @@ export function useCategories(): {
 
         getCategories({
           onSuccess(data) {
-            cachedCategories = data.categories;
+            const sortedCategories = [...data.categories].sort((a, b) => {
+              if (a.name === b.name) {
+                return 0;
+              }
+              return a.name < b.name ? -1 : 1;
+            });
+            cachedCategories = sortedCategories;
             cachedErrorMessage = undefined;
             categoriesHaveLoaded = true;
             resolvePromise();
 
             if (componentIsMounted) {
-              setCategories(data.categories);
+              setCategories(sortedCategories);
               setErrorMessage(undefined);
             }
           },

--- a/src/hooks/useCategories/useCategories.unit.test.tsx
+++ b/src/hooks/useCategories/useCategories.unit.test.tsx
@@ -51,12 +51,14 @@ const mockCategoryFiller: Omit<ICategory, "name"> = {
 const foo: ICategory = { ...mockCategoryFiller, name: "Foo" };
 const bar: ICategory = { ...mockCategoryFiller, name: "Bar" };
 const baz: ICategory = { ...mockCategoryFiller, name: "Baz" };
-const mockCategoryNames = MOCK_DATA.categories.map(({ name }) => name);
 const categoriesEndpoint = `${ENDPOINTS.categories}/all`;
 
 describe("useCategories()", () => {
   describe("given a successful API response", () => {
     it("returns category objects and caches the result", async () => {
+      const mockCategoryNamesSorted = MOCK_DATA.categories
+        .map(({ name }) => name)
+        .sort();
       {
         const {
           categoriesList,
@@ -75,7 +77,7 @@ describe("useCategories()", () => {
           expect(categoriesHaveLoadedElement).toHaveTextContent("true")
         );
         expect(errorMessageElement).toHaveTextContent("UNDEFINED");
-        expect(getCategories()).toEqual(mockCategoryNames);
+        expect(getCategories()).toEqual(mockCategoryNamesSorted);
       }
       {
         const {
@@ -87,7 +89,7 @@ describe("useCategories()", () => {
         // Cached categories are populated on the first render
         expect(categoriesHaveLoadedElement).toHaveTextContent("true");
         expect(errorMessageElement).toHaveTextContent("UNDEFINED");
-        expect(getCategories()).toStrictEqual(mockCategoryNames);
+        expect(getCategories()).toStrictEqual(mockCategoryNamesSorted);
       }
     });
   });
@@ -115,8 +117,8 @@ describe("useCategories()", () => {
       expect(component1.errorMessageElement).toHaveTextContent("UNDEFINED");
       expect(component2.errorMessageElement).toHaveTextContent("UNDEFINED");
 
-      expect(component1.getCategories()).toStrictEqual(["Foo", "Bar"]);
-      expect(component2.getCategories()).toStrictEqual(["Foo", "Bar"]);
+      expect(component1.getCategories()).toStrictEqual(["Bar", "Foo"]);
+      expect(component2.getCategories()).toStrictEqual(["Bar", "Foo"]);
     });
   });
 
@@ -141,7 +143,7 @@ describe("useCategories()", () => {
         expect(component2.categoriesHaveLoadedElement).toHaveTextContent("true")
       );
       expect(component2.errorMessageElement).toHaveTextContent("UNDEFINED");
-      expect(component2.getCategories()).toStrictEqual(["Foo", "Bar"]);
+      expect(component2.getCategories()).toStrictEqual(["Bar", "Foo"]);
 
       // But component1 is not updated after being unmounted
       expect(component1.categoriesHaveLoadedElement).toHaveTextContent("false");
@@ -231,9 +233,9 @@ describe("useCategories()", () => {
       expect(component2.errorMessageElement).toHaveTextContent("UNDEFINED");
       expect(component3.errorMessageElement).toHaveTextContent("UNDEFINED");
 
-      expect(component1.getCategories()).toStrictEqual(["Foo", "Bar"]);
-      expect(component2.getCategories()).toStrictEqual(["Foo", "Bar"]);
-      expect(component3.getCategories()).toStrictEqual(["Foo", "Bar"]);
+      expect(component1.getCategories()).toStrictEqual(["Bar", "Foo"]);
+      expect(component2.getCategories()).toStrictEqual(["Bar", "Foo"]);
+      expect(component3.getCategories()).toStrictEqual(["Bar", "Foo"]);
     });
   });
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,22 +1,45 @@
+import { Link } from "@reach/router";
 import type { RouteComponentProps } from "@reach/router";
-import React from "react";
+import React, { Fragment } from "react";
 
 import { CategoryListItem } from "#components/CategoryListItem";
+import { LoginButton } from "#components/LoginButton";
+import { useCategories } from "#hooks/useCategories";
+import { useAuth } from "#src/hooks/useAuth";
 
 export default function HomePage(_: RouteComponentProps): JSX.Element {
+  const auth = useAuth();
+  const { categories } = useCategories();
+
   return (
     <div>
-      <h2>Browse by category</h2>
-      <CategoryListItem
-        name="Winds"
-        url="/categories/winds/"
-        summary="Move air, make noise"
-      />
-      <CategoryListItem
-        name="Percussion"
-        url="/categories/percussion/"
-        summary="Hit stuff"
-      />
+      <h2>Welcome to the Instrument Catalog!</h2>
+      <p>
+        Here, you can share your knowledge by giving an introduction to your
+        favorite musical instruments and browse the instrument intros that
+        others have posted.
+      </p>
+      {auth.state === "AUTHENTICATED" ? (
+        <p>
+          Post a <Link to="/instruments/new/">New Instrument</Link> to share
+          your knowledge!
+        </p>
+      ) : (
+        <p>
+          <LoginButton /> to post your own instrument knowledge!
+        </p>
+      )}
+      <h2>Browse instruments by category</h2>
+      {categories.map(({ id, name, slug, summary }, index) => (
+        <Fragment key={id}>
+          {index > 0 && <hr />}
+          <CategoryListItem
+            name={name}
+            url={`/categories/${slug}/`}
+            summary={summary}
+          />
+        </Fragment>
+      ))}
     </div>
   );
 }

--- a/tests/integration/home.int.test.tsx
+++ b/tests/integration/home.int.test.tsx
@@ -1,0 +1,52 @@
+import { within } from "@testing-library/react";
+import React from "react";
+
+import {
+  useAuth,
+  mockAuthenticatedUser,
+  LOADING,
+  ERRORED,
+  UNAUTHENTICATED,
+} from "#mocks/useAuth";
+import { App } from "#src/App";
+import { renderWithRouter } from "#test_helpers/renderWithRouter";
+
+describe("<HomePage /> rendered inside <App />", () => {
+  describe("given a user who is logged in", () => {
+    test("call to action is 'post a new instrument'", () => {
+      mockAuthenticatedUser("foo|123");
+      const { container } = renderWithRouter(<App />, "/");
+      const { getByRole, queryByRole } = within(
+        container.querySelector("main") as HTMLElement
+      );
+
+      const newInstrumentLink = getByRole("link", { name: /new instrument/i });
+      const loginButton = queryByRole("button", { name: /log/i });
+
+      expect(newInstrumentLink).toHaveAttribute("href", "/instruments/new/");
+      expect(loginButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given a user who is not logged in", () => {
+    test.each([
+      ["LOADING", LOADING],
+      ["ERRORED", ERRORED],
+      ["UNAUTHENTICATED", UNAUTHENTICATED],
+    ])("call to action is 'log in' when auth state is %s", (_, AUTH_VALUE) => {
+      useAuth.mockReturnValue(AUTH_VALUE);
+      const { container } = renderWithRouter(<App />, "/");
+      const { getByRole, queryByRole } = within(
+        container.querySelector("main") as HTMLElement
+      );
+
+      const newInstrumentLink = queryByRole("link", {
+        name: /new instrument/i,
+      });
+      const loginButton = getByRole("button", { name: /log/i });
+
+      expect(newInstrumentLink).not.toBeInTheDocument();
+      expect(loginButton).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/integration/routes.int.test.tsx
+++ b/tests/integration/routes.int.test.tsx
@@ -24,8 +24,10 @@ describe("<App />", () => {
         const heading1 = await screen.findByRole("heading", { level: 1 });
         expect(heading1).toHaveTextContent(/instrument catalog/i);
 
-        const heading2 = await screen.findByRole("heading", { level: 2 });
-        expect(heading2).toHaveTextContent(/browse by category/i);
+        const [heading2] = await screen.findAllByRole("heading", { level: 2 });
+        expect(heading2).toHaveTextContent(
+          /welcome to the instrument catalog/i
+        );
 
         unmount();
       });


### PR DESCRIPTION
- Add a description of the site and a call to action ("log in" or "create instrument", depending on auth state)
- Sort categories by name. To avoid having a different sort order between the home page and the category page, the sort is done in the `useCategories()` hook so that all components get categories in the same order.
