### PR TITLE
bugfix: Clicking <BurgerButton /> should not log the user out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
-import { Auth0Provider } from "@auth0/auth0-react";
-import type { AppState } from "@auth0/auth0-react";
-import { Router, navigate } from "@reach/router";
+import { Router } from "@reach/router";
 import React, { useState } from "react";
 import { Root, addPrefetchExcludes } from "react-static";
 import styled, { ThemeProvider } from "styled-components";
@@ -51,14 +49,6 @@ const StyledHeader = styled.header`
   }
 `;
 
-const isBrowser = typeof window !== "undefined";
-
-function handleAuthRedirect(appState?: AppState) {
-  if (isBrowser) {
-    navigate(appState?.returnTo ?? window.location.pathname, { replace: true });
-  }
-}
-
 export function App(): JSX.Element {
   const [navIsVisible, setNavIsVisible] = useState(false);
   const toggleNav = () => setNavIsVisible((isVisible) => !isVisible);
@@ -66,36 +56,27 @@ export function App(): JSX.Element {
 
   return (
     <Root>
-      <Auth0Provider
-        domain={process.env.AUTH0_DOMAIN || ""}
-        clientId={process.env.AUTH0_CLIENT_ID || ""}
-        redirectUri={isBrowser ? window.location.origin : ""}
-        onRedirectCallback={handleAuthRedirect}
-        audience={process.env.AUTH0_BACKEND_API_IDENTIFIER || ""}
-        useRefreshTokens
-      >
-        <ThemeProvider theme={defaultTheme}>
-          <StyledHeader>
-            <h1>Instrument Catalog</h1>
-            <BurgerButton
-              className="burger"
-              onClick={toggleNav}
-              navIsVisible={navIsVisible}
-            />
-          </StyledHeader>
-          <Nav onLinkClick={hideNav} visible={navIsVisible} />
-          <main>
-            <Router>
-              <HomePage path="/" />
-              <CategoriesPage path="categories/" />
-              <CategoryPage path="categories/:categorySlug/" />
-              <InstrumentPage path="instruments/:instrumentId/**" />
-              <NewInstrumentPage path="instruments/new/" />
-              <NotFound default />
-            </Router>
-          </main>
-        </ThemeProvider>
-      </Auth0Provider>
+      <ThemeProvider theme={defaultTheme}>
+        <StyledHeader>
+          <h1>Instrument Catalog</h1>
+          <BurgerButton
+            className="burger"
+            onClick={toggleNav}
+            navIsVisible={navIsVisible}
+          />
+        </StyledHeader>
+        <Nav onLinkClick={hideNav} visible={navIsVisible} />
+        <main>
+          <Router>
+            <HomePage path="/" />
+            <CategoriesPage path="categories/" />
+            <CategoryPage path="categories/:categorySlug/" />
+            <InstrumentPage path="instruments/:instrumentId/**" />
+            <NewInstrumentPage path="instruments/new/" />
+            <NotFound default />
+          </Router>
+        </main>
+      </ThemeProvider>
     </Root>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,6 @@
+import { Auth0Provider } from "@auth0/auth0-react";
+import type { AppState } from "@auth0/auth0-react";
+import { navigate } from "@reach/router";
 import React from "react";
 import ReactDOM from "react-dom";
 import { AppContainer } from "react-hot-loader";
@@ -15,10 +18,23 @@ if (typeof document !== "undefined") {
     ? ReactDOM.hydrate
     : ReactDOM.render;
 
+  const handleAuthRedirect = (appState?: AppState) => {
+    navigate(appState?.returnTo ?? window.location.pathname, { replace: true });
+  };
+
   const render = (AppComponent: () => JSX.Element) => {
     renderMethod(
       <AppContainer>
-        <AppComponent />
+        <Auth0Provider
+          domain={process.env.AUTH0_DOMAIN || ""}
+          clientId={process.env.AUTH0_CLIENT_ID || ""}
+          redirectUri={window.location.origin}
+          onRedirectCallback={handleAuthRedirect}
+          audience={process.env.AUTH0_BACKEND_API_IDENTIFIER || ""}
+          useRefreshTokens
+        >
+          <AppComponent />
+        </Auth0Provider>
       </AppContainer>,
       target
     );


### PR DESCRIPTION
**The bug:**

When the user clicked on the burger button to open the mobile menu, the user was logged out. This only affected users with narrow viewports (and possibly assistive devices?) because the burger button is hidden on larger viewports.

**The cause and the fix:**

The logout was probably due to `<Auth0Provider />` reverting to its initial values when it was rerendered. `<Auth0Provider />` was inside the `<App />` component. `<App />` holds the state for opening and closing the mobile menu, so it must rerender when a click on the burger button causes its state to change.

The bug was resolved by reversing the nesting, rendering `<App />` inside of `<Auth0Provider />`.

**Regression testing:**

I wasn't able to write a test replicating the bug, unfortunately. I tried mocking `<Auth0Provider />` and `useAuth0()` with `React.useContext()`, but the mocked provider maintained its own state when `<App />`'s state was updated by clicking the burger button. This suggests that the state reset is caused by the specific implementation of `<Auth0Provider />`'s state management, or possibly by some behavior of `jsdom` that's different from the browser.
